### PR TITLE
unit test database location is located from testing.py location

### DIFF
--- a/plantdb/testing.py
+++ b/plantdb/testing.py
@@ -26,13 +26,13 @@
 import tempfile
 import unittest
 
-from os import getcwd
 from os.path import join, abspath
+from pathlib import Path
 from dirsync import sync
 from plantdb import FSDB
 
-cwd = getcwd()
-DATABASE_LOCATION = abspath(join(cwd, "tests", "testdata"))
+parent_dir = Path(__file__).resolve().parents[1]
+DATABASE_LOCATION = abspath(join(parent_dir, "tests", "testdata"))
 
 
 class TemporaryCloneDB(object):


### PR DESCRIPTION
The Problem:
In the unit tests, the database used to test some features is located related to current working directory which makes the failure happen when the tests are run from an other directory than `plandb`.

This PR:
Aims to locate the test database from `testing.py` which makes the unit tests results independent from where we run them.