### PR TITLE
Made the Visualization/measures.json optional 

### DIFF
--- a/src/plantdb/bin/romi_scanner_rest_api.py
+++ b/src/plantdb/bin/romi_scanner_rest_api.py
@@ -172,13 +172,13 @@ def fmt_scan(scan):
                 res["data"]["angles"]["measured_angles"] = metadata["measures"]["angles"]
             except KeyError:
                 measures = io.read_json(fileset_visu.get_file(files_metadata["measures"]))
-                res["data"]["angles"]["measured_angles"] = measures["angles"]
+                res["data"]["angles"]["measured_angles"] = measures["angles"] if "angles" in measures.keys() else []
 
             try:
                 res["data"]["angles"]["measured_internodes"] = metadata["measures"]["internodes"]
             except KeyError:
                 measures = io.read_json(fileset_visu.get_file(files_metadata["measures"]))
-                res["data"]["angles"]["measured_internodes"] = measures["internodes"]
+                res["data"]["angles"]["measured_internodes"] = measures["internodes"] if "internodes" in measures.keys() else []
 
     # backward compatibility
     try:

--- a/src/plantdb/bin/romi_scanner_rest_api.py
+++ b/src/plantdb/bin/romi_scanner_rest_api.py
@@ -6,6 +6,7 @@ Serve the plant database through a REST API.
 """
 import argparse
 import json
+import logging
 import os
 
 from flask import Flask
@@ -84,7 +85,10 @@ def fmt_scan_minimal(scan):
     has_segmentation2D = files_metadata["segmentation2d_evaluation"] is not None
     has_segmentedPcd_evaluation = files_metadata["segmented_pcd_evaluation"] is not None
     has_point_cloud_evaluation = files_metadata["point_cloud_evaluation"] is not None
-    has_manual_measures = "measures" in metadata or files_metadata["measures"] is not None
+    has_manual_measures = "measures" in metadata or \
+        (files_metadata["measures"] is not None and \
+        len(io.read_json(fileset_visu.get_file(files_metadata["measures"]))) > 0)
+
     has_segmented_point_cloud = len([f.id for f in scan.get_filesets() if 'SegmentedPointCloud' in f.id]) > 0
 
     return {


### PR DESCRIPTION
if "measure"-related keys cannot be found , the API returns an empty array. It's not the cleanest way to do it, but it's the way that requires the less changes (cf https://github.com/romi/plant-3d-explorer/issues/96)