### PR TITLE
Add NoAuthSessionManager and enable auth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ docker run -p 5000:5000 -v $ROMI_DB:/myapp/db -it roboticsmicrofarms/plantdb
 
 **Obviously, you have to install docker first!**
 
+### Production ready
+
+If you want to set up a database for multiple users and want to **secure it by enabling authentication**, you must secure it by setting a `.env` at its root directory as follows:
+```dotenv
+ROMI_DB_NOAUTH="0"
+```
+Or set it as an environment variable if you prefer, as done in our distributed docker image.
+Any system-wide environment variable will take precedence over variables in the `.env` file.
+
 ## Usage
 
 ### Python API
@@ -186,13 +195,12 @@ docker run -p 5000:5000 -v $ROMI_DB:/myapp/db -it roboticsmicrofarms/plantdb
 Here is a minimal example how to use the `plantdb` library in Python:
 
 ```python
-# Get the environment variable $ROMI_DB
 import os
-
-db_path = os.environ['ROMI_DB']
-# Use it to connect to DB:
 from plantdb.commons.fsdb.core import FSDB
 
+# Get the environment variable $ROMI_DB
+db_path = os.getenv('ROMI_DB')
+# Use it to connect to DB:
 db = FSDB(db_path)
 db.connect()
 # Access to a dataset named `real_plant` (from the example database)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,6 +100,8 @@ ENV DEB_PYTHON_INSTALL_LAYOUT=deb_system
 ENV PLANTDB_API_PREFIX=""
 # Location of the database folder to serve:
 ENV ROMI_DB="/myapp/db"
+# Force credentials usage on this database
+ENV ROMI_DB_NOAUTH="0"
 
 # Change Shell to 'bash', default is 'sh':
 SHELL ["/bin/bash", "-c"]

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -27,6 +27,7 @@ Usage Examples
 {'username': 'alice', 'issued_at': 1769011058, 'expires_at': 1769012858, 'jti': 'HVaAR4XHmIJgCKbZMDqmwg', 'issuer': 'plantdb-api', 'audience': 'plantdb-client'}
 >>> new_token = manager.refresh_session(token)
 """
+import os
 import secrets
 import threading
 import time
@@ -550,6 +551,8 @@ class NoAuthSessionManager(SessionManager):
     """
 
     def __init__(self, session_timeout: int = 3600) -> None:
+        if os.environ.get('ROMI_DB_NOAUTH', 1) == 0:
+            raise RuntimeError('Unable to use NoAuthSessionManager, forbidden by environment variable!')
         # Force a single‑session policy; the real admin manager does the same.
         super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
         self._admin_username = "admin"

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -551,11 +551,12 @@ class NoAuthSessionManager(SessionManager):
     """
 
     def __init__(self, session_timeout: int = 3600) -> None:
+        # Abort if environment explicitly disables NoAuth mode.
         if os.environ.get('ROMI_DB_NOAUTH', 1) == 0:
             raise RuntimeError('Unable to use NoAuthSessionManager, forbidden by environment variable!')
-        # Force a single‑session policy; the real admin manager does the same.
+        # Initialize base SessionManager with single‑session limit.
         super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
-        self._admin_username = "admin"
+        self._admin_username = "admin"  # Fixed admin username.
         # Create the admin session eagerly.
         self._admin_token = super().create_session(self._admin_username)
 
@@ -570,30 +571,26 @@ class NoAuthSessionManager(SessionManager):
     # Overridden SessionManager API
     # ------------------------------------------------------------------
     def create_session(self, username: str | None = None) -> str | None:
-        """
-        Ignore the supplied *username* – always return the pre‑created admin token.
-        This mirrors the behavior of ``AdminSessionManager`` but without any conditional logic.
-        """
+        """Ignore the supplied `username` and always return the pre‑created admin token."""
         return self._admin_token
 
     def validate_session(self, session_id: str) -> dict | None:
         """
-        Validate the stored admin token.  If it has expired, recreate it
-        and return the fresh session information.
+        Validate the stored admin token.
+
+        If it has expired, recreate it and return the fresh session information.
         """
         # First try the existing token; ``super().validate_session`` also updates ``last_accessed``.
         session = super().validate_session(self._admin_token)
         if session is None:
-            # Token expired → make a new one.
+            # Token is expired, so we generate a new one.
             self._admin_token = super().create_session(self._admin_username)
             session = super().validate_session(self._admin_token)
         return session
 
     def session_username(self, session_id: str) -> str | None:
         """Always return ``admin`` for any session identifier."""
-        # We bypass the parent implementation because it would look up the
-        # token in ``self.sessions`` – we know the admin token is always
-        # present (or recreated above).
+        # We bypass the parent implementation because it would look up the token in ``self.sessions``
         return self._admin_username
 
 

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -520,6 +520,80 @@ class SingleSessionManager(SessionManager):
         super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
 
 
+class NoAuthSessionManager(SessionManager):
+    """
+    A session manager for testing where every request is considered
+    authenticated as the built‑in ``admin`` user.
+
+    - The admin token is created once at construction and reused.
+    - ``validate_session`` always succeeds (refreshes the token only when it has expired).
+    - Suitable for use in `plantdb.commons.fsdb.core.FSDB` tests and
+      docstring examples where security is irrelevant.
+
+    Examples
+    --------
+    >>> from plantdb.commons.auth.session import NoAuthSessionManager
+    >>> noauth_sm = NoAuthSessionManager()
+    >>> token = noauth_sm.admin_token()
+    >>> noauth_sm.validate_session(token)['username']
+    'admin'
+    >>> # Any request that expects a session manager can now receive `noauth_sm` without worrying about authentication.
+    >>> from plantdb.commons.test_database import setup_test_database
+    >>> from plantdb.commons.fsdb.core import FSDB
+    >>> db_path = setup_test_database('real_plant')
+    >>> db = FSDB(db_path, session_manager=NoAuthSessionManager())
+    >>> db.connect()
+    >>> scan = db.get_scan('real_plant')  # no need to log in to access the dataset
+    >>> scan.set_metadata('test', "No authentication required to write stuff!")
+    >>> print(scan.get_metadata('test'))
+    No authentication required to write stuff!
+    """
+
+    def __init__(self, session_timeout: int = 3600) -> None:
+        # Force a single‑session policy; the real admin manager does the same.
+        super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
+        self._admin_username = "admin"
+        # Create the admin session eagerly.
+        self._admin_token = super().create_session(self._admin_username)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def admin_token(self) -> str | None:
+        """Return the (static) admin token."""
+        return self._admin_token
+
+    # ------------------------------------------------------------------
+    # Overridden SessionManager API
+    # ------------------------------------------------------------------
+    def create_session(self, username: str | None = None) -> str | None:
+        """
+        Ignore the supplied *username* – always return the pre‑created admin token.
+        This mirrors the behavior of ``AdminSessionManager`` but without any conditional logic.
+        """
+        return self._admin_token
+
+    def validate_session(self, session_id: str) -> dict | None:
+        """
+        Validate the stored admin token.  If it has expired, recreate it
+        and return the fresh session information.
+        """
+        # First try the existing token; ``super().validate_session`` also updates ``last_accessed``.
+        session = super().validate_session(self._admin_token)
+        if session is None:
+            # Token expired → make a new one.
+            self._admin_token = super().create_session(self._admin_username)
+            session = super().validate_session(self._admin_token)
+        return session
+
+    def session_username(self, session_id: str) -> str | None:
+        """Always return ``admin`` for any session identifier."""
+        # We bypass the parent implementation because it would look up the
+        # token in ``self.sessions`` – we know the admin token is always
+        # present (or recreated above).
+        return self._admin_username
+
+
 def _derive_key_argon2(password: str) -> bytes:
     """Derive a 64‑byte (512‑bit) secret using Argon2.
 

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -1224,13 +1224,17 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> token = db.login('guest', 'guest')
         ERROR    [FSDB] Failed to login as 'guest'! Another user is logged in.
         >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
         >>> token = db.login('guest', 'guest')
+        >>> print(len(token))
+        43
         >>> db.disconnect()
         """
         if self.validate_user(username, password):
@@ -1266,9 +1270,10 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
         >>> db.logout()  # log out from NO session
@@ -1318,16 +1323,18 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
+        INFO     [RBACManager] User 'admin' is creating new user 'batman' with roles=<Role.CONTRIBUTOR: 'contributor'>.
         INFO     [UserManager] Welcome Bruce Wayne, please log in...'
         >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
         >>> token = db.login('batman', 'joker')
-        >>> print(token)
-        WoBlNjJPmJHEwuFG3NAyrFtKMHnEg-BRjSplJU-uMbU
+        >>> print(len(token))
+        43
         >>> db.disconnect()
         """
         _ = self.rbac_manager.create_user(current_user, new_username, fullname, password, roles)
@@ -1361,10 +1368,10 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         INFO     [UserManager] Welcome Bruce Wayne, please log in...'
         >>> db.logout()  # log out from 'admin' session
@@ -1375,6 +1382,8 @@ class FSDB(db.DB):
         >>> db.logout()  # log out from 'batman' session
         (True, 'batman')
         >>> token = db.login('batman', 'alfred')  # login with new password
+        >>> print(len(token))
+        43
         >>> db.disconnect()
         """
         return self.rbac_manager.users.update_password(current_user.username, old_password, new_password)
@@ -1384,7 +1393,7 @@ class FSDB(db.DB):
     @require_authentication
     def create_api_token(
             self, token_exp: int,
-            datasets: dict[str, tuple[Permission, ...] | Permission],
+            datasets: dict[str, list[Permission] | Permission],
             current_user: User | None = None, **kwargs
     ) -> str:
         """
@@ -1399,25 +1408,39 @@ class FSDB(db.DB):
         ----------
         token_exp : int
             The expiration duration of the API token in seconds.
-        datasets : dict of str to tuple of Permission or Permission
+        datasets : dict[str, list[Permission] | Permission]
             A dictionary where the keys are dataset names, and the values are either
             a tuple of `Permission` instances or a single `Permission` instance
             defining the access levels for each dataset.
         current_user : plantdb.commons.fsdb.auth.models.User, optional
             The user object representing the currently authenticated user. The username
             from this object is used to associate the API token.
-        **kwargs
-            Additional keyword arguments passed for possible extended functionality.
+
+        Other Parameters
+        ----------------
+        token : str
+            The token to use to authenticate against the ``JWTSessionManager``.
 
         Returns
         -------
         str
             The generated API token.
+
+        Examples
+        --------
+        >>> from plantdb.commons.test_database import test_database
+        >>> from plantdb.commons.auth.session import JWTSessionManager
+        >>> from plantdb.commons.auth.models import Permission
+        >>> db = test_database(session_manager=JWTSessionManager())
+        >>> db.connect()
+        >>> access_token, refresh_token = db.login('admin', 'admin')
+        >>> api_token = db.create_api_token(3600, {'real_plant_analyzed': [Permission.WRITE]}, token=access_token)
+        >>> db.disconnect()
         """
         if not isinstance(self.session_manager, JWTSessionManager):
             raise RuntimeError("Session manager must be an instance of JWTSessionManager.")
-        session_manager: JWTSessionManager = self.session_manager
-        return session_manager.create_api_token(current_user.username, token_exp, datasets)
+
+        return self.session_manager.create_api_token(current_user.username, token_exp, datasets)
 
     def get_guest_user(self) -> User:
         """Retrieve the guest user information from the RBAC manager.
@@ -1460,14 +1483,12 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        >>> db.logout()
-        INFO     [FSDB] Successfully logged out from 'admin'.
-        >>> token = db.login('guest', 'guest')
-        INFO     [FSDB] Successfully logged in as 'guest'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.get_username(token)
-        'guest'
+        'admin'
         >>> db.disconnect()
         """
         return self.session_manager.session_username(token)
@@ -1493,14 +1514,13 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.get_user_data(username='admin')
         User(username='admin', fullname='PlantDB Admin', password_hash='$argon2id$v=19$m=65536,t=3,p=4$zMr0ZhclnHHdOgwWKv3Hbg$SZshbPdNiCdBONb8vgzZAKyWPl5sNIUwB8mQWkzGYOQ', roles={<Role.ADMIN: 'admin'>}, created_at=datetime.datetime(2026, 1, 29, 17, 22, 49, 683163), permissions=None, last_login=datetime.datetime(2026, 1, 29, 17, 22, 49, 770793), is_active=True, failed_attempts=0, last_failed_attempt=None, locked_until=None, password_last_change=datetime.datetime(2026, 1, 29, 17, 22, 49, 683163))
-        >>> db.logout()  # log out from 'admin' session
-        (True, 'admin')
-        >>> token = db.login('guest', 'guest')
-        >>> user_data = db.get_user_data(token=token)
+        >>> user_data = db.get_user_data(username='guest')
         >>> print(user_data.fullname)
         PlantDB Guest
         >>> db.disconnect()
@@ -1560,8 +1580,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1608,8 +1630,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1657,8 +1681,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1703,8 +1729,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1742,8 +1770,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print([g.name for g in db.list_groups()])
@@ -1784,8 +1814,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print([g.name for g in db.get_user_groups('batman')])

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -116,6 +116,7 @@ from plantdb.commons.auth.models import TokenUser
 from plantdb.commons.auth.models import User
 from plantdb.commons.auth.rbac import RBACManager
 from plantdb.commons.auth.session import JWTSessionManager
+from plantdb.commons.auth.session import NoAuthSessionManager
 from plantdb.commons.auth.session import SessionManager
 from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.fsdb.exceptions import FileNotFoundError
@@ -252,7 +253,7 @@ def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs) -
     >>> import os
     >>> from plantdb.commons.test_database import dummy_db
     >>> from plantdb.commons.fsdb.core import get_logged_username
-    >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
+    >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
     >>> get_logged_username(db)
     'admin'
     >>> db.logout()
@@ -260,8 +261,8 @@ def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs) -
     True
     >>> get_logged_username(db, default_user='guest')
     """
-    if isinstance(fsdb.session_manager, SingleSessionManager):
-        # If a Single SessionManager, get the username from the session manager (as only one user can be logged at once)
+    if isinstance(fsdb.session_manager, (NoAuthSessionManager, SingleSessionManager)):
+        # Get the username from the session manager (as only one user can be logged at once)
         try:
             session = list(fsdb.session_manager.sessions.keys())[0]
         except IndexError:
@@ -576,7 +577,7 @@ class FSDB(db.DB):
     <class 'plantdb.commons.fsdb.core.Scan'>
     >>> db.disconnect()  # clean up (delete) the temporary dummy database
 
-    >>> # EXAMPLE 2: Use a local database:
+    >>> # EXAMPLE 2: Use a local database with a :
     >>> import os
     >>> from plantdb.commons.fsdb.core import FSDB
     >>> db = FSDB(os.environ.get('ROMI_DB', "/data/ROMI/DB/"), log_level="DEBUG")
@@ -592,7 +593,7 @@ class FSDB(db.DB):
     def __init__(self, basedir: Union[str, Path],
                  required_filesets: Optional[List[str]] = None,
                  logger: Optional[logging.Logger] = None,
-                 session_manager: Union[SingleSessionManager, SessionManager, JWTSessionManager] = None,
+                 session_manager: SessionManager = None,
                  session_timeout: int = 3600, max_login_attempts: int = 3,
                  lockout_duration: int = 900, max_concurrent_sessions: int = 10, **kwargs):
         """Database constructor.
@@ -609,9 +610,9 @@ class FSDB(db.DB):
             Use `[]` to accept any subdirectory of `basedir` as a valid "scan".
         logger : logging.Logger, optional
             Logger instance to use for logging. Defaults to the module logger.
-        session_manager : Union[SingleSessionManager, SessionManager, JWTSessionManager], optional
+        session_manager : SessionManager, optional
             The session manager to use for session authentication.
-            Defaults to ``SingleSessionManager``.
+            Defaults to ``NoAuthSessionManager`` if ``'no_auth'`` kwarg is set to `True``, else ``SingleSessionManager``.
         session_timeout : int, optional
             Session timeout in seconds.
             Defaults to 3600 (1 hour).
@@ -659,15 +660,17 @@ class FSDB(db.DB):
 
         # Initialize the session manager
         if session_manager is None:
-            self.session_manager = SingleSessionManager(
-                session_timeout=session_timeout,
-            )
-        elif isinstance(session_manager, (SingleSessionManager, SessionManager, JWTSessionManager)):
+            if kwargs.get('no_auth', False):
+                self.session_manager = NoAuthSessionManager(session_timeout=session_timeout)
+            else:
+                self.session_manager = SingleSessionManager(session_timeout=session_timeout)
+        elif isinstance(session_manager,
+                        (SingleSessionManager, SessionManager, JWTSessionManager, NoAuthSessionManager)):
             self.session_manager = session_manager
         else:
             raise ValueError(
                 f"session_manager must be an instance of 'SingleSessionManager', 'SessionManager', "
-                f"or 'JWTSessionManager', got {type(session_manager)}"
+                f" 'JWTSessionManager' or 'NoAuthSessionManager', got {type(session_manager)}"
             )
 
         # Initialize RBAC manager with groups file in basedir
@@ -1196,7 +1199,7 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
+        >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
         >>> db.validate_user('guest', 'guest')
         True
         >>> db.disconnect()
@@ -1222,7 +1225,7 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
+        >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
         >>> token = db.login('guest', 'guest')
         ERROR    [FSDB] Failed to login as 'guest'! Another user is logged in.
         >>> db.logout()  # log out from 'admin' session
@@ -1233,7 +1236,8 @@ class FSDB(db.DB):
         if self.validate_user(username, password):
 
             # If a SingleSessionManager and a currently logged user, abort
-            if isinstance(self.session_manager, SingleSessionManager) and self.session_manager.has_logged_user():
+            if isinstance(self.session_manager,
+                          (NoAuthSessionManager, SingleSessionManager)) and self.session_manager.has_logged_user():
                 current_username = get_logged_username(self)
                 if current_username:
                     if current_username != username:
@@ -1973,7 +1977,7 @@ class Scan(db.Scan, MetadataManager):
         """A property method to retrieve or set the `owner` of a resource.
 
         If the `owner` is not already defined in the resource's metadata, this property
-        ensures that a default owner is assigned (using a guest user). The updated metadata
+        ensures that a default owner is assigned (using the 'guest' user). The updated metadata
         is then stored in the database, and the resource is reloaded.
 
         Returns
@@ -1987,7 +1991,7 @@ class Scan(db.Scan, MetadataManager):
         _store_scan_metadata : Saves updated metadata to the database.
         db.reload : Reloads the resource from the database after updates.
         """
-        # If no owner is defined, set it to the guest user, save it and reload it into the DB
+        # If no owner is defined, set it to the 'guest' user, save it and reload it into the DB
         if 'owner' not in self.metadata:
             metadata = self.db.rbac_manager.ensure_scan_owner(self.metadata)
             _set_metadata(self.metadata, metadata, None)

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -630,6 +630,9 @@ class FSDB(db.DB):
         ----------------
         log_level : str
             A logging level to set for the logger. Defaults to ``INFO``.
+        no_auth : bool
+            A boolean flag to switch between session managers.
+            If ``True``, use `NoAuthSessionManager` else use `SingleSessionManager`.
 
         Raises
         ------
@@ -882,6 +885,7 @@ class FSDB(db.DB):
 
         Examples
         --------
+        >>> # Example #1 - API demo
         >>> from plantdb.commons.test_database import dummy_db
         >>> db = dummy_db(with_scan=True)
         >>> scan = db.get_scan('myscan_001')
@@ -892,6 +896,18 @@ class FSDB(db.DB):
         >>> unknown_scan = db.get_scan('unknown')
         plantdb.commons.fsdb.ScanNotFoundError: Unknown scan id 'unknown'!
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
+
+        >>> # Example #2 - API demo with authentication
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> scan = db.get_scan('real_plant_analyzed')
+        plantdb.commons.fsdb.exceptions.NoAuthUserError: No authenticated user!
+        >>> token = db.login('admin', 'admin')
+        >>> scan = db.get_scan('real_plant_analyzed')
+        >>> print(scan.id)
+        real_plant_analyzed
+        >>> db.disconnect()
         """
         with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, current_user.username, LockLevel.SCAN):
             if not self.scan_exists(scan_id):
@@ -2158,6 +2174,18 @@ class Scan(db.Scan, MetadataManager):
         any
             If `key` is ``None``, returns a dictionary.
             Else, returns the value attached to this key.
+
+        Examples
+        --------
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
+        >>> scan = db.get_scan('real_plant_analyzed')
+        >>> scan.get_metadata('owner')
+        'guest'
+        >>> db.logout()
+        >>> scan.get_metadata('owner')  # Can still access it as 'guest' user
         """
         # Use shared lock for read operations
         with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username, LockLevel.SCAN):

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -414,9 +414,6 @@ def _load_fileset_files(fileset, fileset_info):
         for n, file_info in enumerate(files_info):
             try:
                 file = _load_file(fileset, file_info)
-                fid = file_info.get("id")
-                if fid is None:
-                    raise FileNotFoundError(f"Missing 'id' for the {n}-th 'files' entry.")
             except FileNoIDError:
                 logger.error(f"Could not get an 'id' entry for the {n}-th 'files' entry from '{scan_id}'.")
                 logger.debug(f"Current `file_info`: {file_info}")
@@ -426,6 +423,7 @@ def _load_fileset_files(fileset, fileset_info):
                 logger.error(f"Could not find file '{fname}' for '{scan_id}/{fs_id}'.")
                 logger.debug(f"Current `file_info`: {file_info}")
             else:
+                fid = file_info.get("id")
                 files[fid] = file
     else:
         raise IOError(f"Expected a list of files in `files.json` from dataset '{fileset.scan.id}'!")

--- a/src/commons/plantdb/commons/fsdb/serialization.py
+++ b/src/commons/plantdb/commons/fsdb/serialization.py
@@ -131,7 +131,7 @@ def _parse_file(fileset, file_info):
     path = _file_path(file)
     if not path.is_file():
         logger.debug(f"Missing file: {path}")
-        raise FileNotFoundError(f"File: Not found at '{path}'")
+        raise FileNotFoundError(fileset, fid)
     return file
 
 

--- a/src/commons/plantdb/commons/io.py
+++ b/src/commons/plantdb/commons/io.py
@@ -102,8 +102,7 @@ Trained tensor, read and written using ``torch``.
 import tempfile
 from pathlib import Path
 
-from plantdb.commons import db
-from plantdb.commons import fsdb
+from plantdb.commons.db import File
 from plantdb.commons.log import get_logger
 
 logger = get_logger(__name__)
@@ -114,7 +113,7 @@ def _reader(file, reader, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
     reader : function
         The function to use to read the data.
@@ -125,7 +124,7 @@ def _reader(file, reader, **kwargs):
         The loaded data.
     """
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the file with the selected reader:
     with open(file, 'r') as f:
@@ -138,7 +137,7 @@ def _write_db_file(dbfile, data, ext, writer, **kwargs):
 
     Parameters
     ----------
-    dbfile : plantdb.commons.db.File
+    dbfile : plantdb.commons.File
         The ``File`` instance to save the data to.
     data : Any
         The data to save.
@@ -160,7 +159,7 @@ def _writer(file, data, ext, writer, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the point cloud data to the given file path, ignoring the extension parameter `ext`.
     data : Any
@@ -170,7 +169,7 @@ def _writer(file, data, ext, writer, **kwargs):
     writer : function
         The function to use to write the `data`.
     """
-    if isinstance(file, db.File):
+    if isinstance(file, File):
         _write_db_file(file, data, ext, writer, **kwargs)
     else:
         writer(file, data, **kwargs)
@@ -182,7 +181,7 @@ def read_json(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -207,7 +206,7 @@ def read_json(file, **kwargs):
     """
     import json
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the file:
     with open(file, mode='r') as f:
@@ -238,7 +237,7 @@ def write_json(file, data, ext="json", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : dict
@@ -267,7 +266,7 @@ def read_toml(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -292,7 +291,7 @@ def read_toml(file, **kwargs):
     """
     import toml
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the file:
     with open(file, mode='r') as f:
@@ -321,7 +320,7 @@ def write_toml(file, data, ext="toml", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : dict
@@ -350,7 +349,7 @@ def read_image(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -377,7 +376,7 @@ def read_image(file, **kwargs):
     """
     import imageio.v3 as iio
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return iio.imread(file, **kwargs)
 
@@ -424,7 +423,7 @@ def write_image(file, data, ext="png", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : array like
@@ -455,7 +454,7 @@ def read_volume(file, ext="tiff", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
     ext : str, optional
         File extension, defaults to "tiff".
@@ -484,7 +483,7 @@ def read_volume(file, ext="tiff", **kwargs):
     """
     import imageio.v3 as iio
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return iio.imread(file, **kwargs)
 
@@ -522,7 +521,7 @@ def write_volume(file, data, ext="tiff", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File
+    file : plantdb.commons.File
         The `File` object used to write the associated file.
     data : array like
         The 3D array to save as volume image.
@@ -558,7 +557,7 @@ def read_npz(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -585,7 +584,7 @@ def read_npz(file, **kwargs):
     """
     import numpy as np
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return dict(np.load(file, **kwargs))
 
@@ -610,7 +609,7 @@ def write_npz(file, data, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : dict of numpy.ndarray
@@ -639,7 +638,7 @@ def read_point_cloud(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -670,7 +669,7 @@ def read_point_cloud(file, **kwargs):
     """
     from open3d import io
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return io.read_point_cloud(str(file), **kwargs)
 
@@ -695,7 +694,7 @@ def write_point_cloud(file, data, ext="ply", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : open3d.geometry.PointCloud
@@ -727,7 +726,7 @@ def read_triangle_mesh(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -737,7 +736,7 @@ def read_triangle_mesh(file, **kwargs):
     """
     from open3d import io
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return io.read_triangle_mesh(str(file), **kwargs)
 
@@ -762,7 +761,7 @@ def write_triangle_mesh(file, data, ext="ply", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : open3d.geometry.TriangleMesh
@@ -779,7 +778,7 @@ def read_voxel_grid(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -789,7 +788,7 @@ def read_voxel_grid(file, **kwargs):
     """
     from open3d import io
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return io.read_voxel_grid(str(file), **kwargs)
 
@@ -814,7 +813,7 @@ def write_voxel_grid(file, data, ext="ply", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File
+    file : plantdb.commons.File
         The `File` object used to write the associated file.
     data : open3d.geometry.VoxelGrid
         The voxel grid object to save.
@@ -835,7 +834,7 @@ def read_graph(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -864,7 +863,7 @@ def read_graph(file, **kwargs):
     """
     import pickle
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the pickled file:
     with open(file, mode='rb') as f:
@@ -897,7 +896,7 @@ def write_graph(file, data, ext="p", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : networkx.Graph
@@ -927,7 +926,7 @@ def read_torch(file, ext="pt", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
     ext : str, optional
         File extension, defaults to "pt".
@@ -950,7 +949,7 @@ def read_torch(file, ext="pt", **kwargs):
     """
     import torch
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return torch.load(file, **kwargs)
 
@@ -975,7 +974,7 @@ def write_torch(file, data, ext="pt", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : TorchTensor

--- a/src/commons/plantdb/commons/test_database.py
+++ b/src/commons/plantdb/commons/test_database.py
@@ -67,12 +67,11 @@ from tempfile import mkdtemp
 from zipfile import ZipFile
 
 import requests
+from tqdm import tqdm
 
 from plantdb.commons.auth.session import NoAuthSessionManager
 from plantdb.commons.auth.session import SessionManager
-from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.log import get_logger
-from tqdm import tqdm
 
 DATASET = ["real_plant", "real_plant_analyzed",
            "virtual_plant", "virtual_plant_analyzed",
@@ -234,7 +233,7 @@ def _test_hash(tmp_fname, hash_value, hash_method="md5"):
     return
 
 
-def _get_archive(archive, force=False) :
+def _get_archive(archive, force=False) -> Path:
     """Download and verify an archive file from a given URL.
 
     This function retrieves an archive file from a specified URL.
@@ -251,7 +250,7 @@ def _get_archive(archive, force=False) :
 
     Returns
     -------
-    Path
+    pathlib.Path
         The path to the downloaded and verified archive file.
     """
     url = ZIP_URLS[archive]
@@ -265,7 +264,7 @@ def _get_archive(archive, force=False) :
     return tmp_fname
 
 
-def _get_extract_archive(archive, out_path=TEST_DIR, keep_tmp=False, force=False):
+def _get_extract_archive(archive, out_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract an archive from ZENODO.
 
     Parameters
@@ -302,7 +301,7 @@ def _get_extract_archive(archive, out_path=TEST_DIR, keep_tmp=False, force=False
     return out_path / archive
 
 
-def get_test_dataset(dataset, db_path=TEST_DIR, keep_tmp=False, force=False):
+def get_test_dataset(dataset, db_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract a test dataset from ZENODO.
 
     Parameters
@@ -334,7 +333,7 @@ def get_test_dataset(dataset, db_path=TEST_DIR, keep_tmp=False, force=False):
     return db_path
 
 
-def get_models_dataset(db_path=TEST_DIR, keep_tmp=False, force=False):
+def get_models_dataset(db_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract the trained CNN model from ZENODO.
 
     Parameters
@@ -364,7 +363,7 @@ def get_models_dataset(db_path=TEST_DIR, keep_tmp=False, force=False):
     return db_path
 
 
-def get_configs(db_path=TEST_DIR, keep_tmp=False, force=False):
+def get_configs(db_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract the pipeline configurations from ZENODO.
 
     Parameters
@@ -394,7 +393,7 @@ def get_configs(db_path=TEST_DIR, keep_tmp=False, force=False):
     return db_path
 
 
-def setup_empty_database(db_path=None):
+def setup_empty_database(db_path=None) -> Path:
     """Sets up an empty ROMI database.
 
     Sets up necessary marker file and ensures the absence of a lock file.
@@ -443,7 +442,8 @@ def setup_empty_database(db_path=None):
     return db_path
 
 
-def setup_test_database(dataset, db_path=TEST_DIR, keep_tmp=True, with_configs=False, with_models=False, force=False):
+def setup_test_database(dataset, db_path=TEST_DIR,
+                        keep_tmp=True, with_configs=False, with_models=False, force=False) -> Path:
     """Download and extract the test database from ZENODO.
 
     Parameters
@@ -570,21 +570,22 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     >>> db.disconnect()
     """
     from plantdb.commons.fsdb.core import FSDB
-    # Use the 'no_auth' keyword argument to define the correct session manager
-    if kwargs.pop('no_auth', False):
-        session_manager = NoAuthSessionManager()
-    else:
-        session_manager = SingleSessionManager()
+    # Extract the 'no_auth' keyword argument to pass it to FSDB.__init__
+    no_auth = kwargs.pop('no_auth', False)
     # If a valid session manager is provided as input, use it
     in_manager = kwargs.pop('session_manager', None)
-    if in_manager and isinstance(in_manager, SessionManager):
+    if isinstance(in_manager, SessionManager):
         session_manager = in_manager
+    else:
+        session_manager = None
 
     # Create the test database with selected dataset and session manager
     if dataset is None:
-        return FSDB(setup_empty_database(db_path=db_path), session_manager=session_manager)
+        return FSDB(setup_empty_database(db_path=db_path),
+                    session_manager=session_manager, no_auth=no_auth)
     else:
-        return FSDB(setup_test_database(dataset, db_path=db_path, **kwargs), session_manager=session_manager)
+        return FSDB(setup_test_database(dataset, db_path=db_path, **kwargs),
+                    session_manager=session_manager, no_auth=no_auth)
 
 
 def dummy_db(with_scan=False, with_fileset=False, with_file=False):

--- a/src/commons/plantdb/commons/test_database.py
+++ b/src/commons/plantdb/commons/test_database.py
@@ -67,6 +67,8 @@ from tempfile import mkdtemp
 from zipfile import ZipFile
 
 import requests
+
+from plantdb.commons.auth.session import NoAuthSessionManager
 from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.log import get_logger
 from tqdm import tqdm
@@ -513,7 +515,7 @@ def setup_test_database(dataset, db_path=TEST_DIR, keep_tmp=True, with_configs=F
     db.connect()
     db.list_scans(owner_only=False)
     for scan_name, scan in db.scans.items():
-        _ = scan.owner  # get the owner of the scan, if unknown, it will be set to the anonymous user
+        _ = scan.owner  # get the owner of the scan, if unknown, it will be set to the 'guest' user
     db.disconnect()
 
     logger.info(f"The test database is set up under '{db_path}'.")
@@ -535,6 +537,8 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
 
     Other Parameters
     ----------------
+    session_manager : SessionManager
+        The session manager to use, defaults to ``NoAuthSessionManager``.
     keep_tmp : bool
         Whether to keep the temporary files. Defaults to ``False``.
     with_configs : bool
@@ -554,14 +558,14 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     >>> from plantdb.commons.test_database import test_database
     >>> db = test_database()
     >>> db.connect()
-    >>> db.list_scans()
+    >>> db.list_scans(owner_only=False)
     ['real_plant_analyzed']
     >>> db.path()
     PosixPath('/tmp/ROMI_DB_********')
     >>> db.disconnect()
     """
     from plantdb.commons.fsdb.core import FSDB
-    session_manager = kwargs.pop('session_manager', None)
+    session_manager = kwargs.pop('session_manager', NoAuthSessionManager())
     if dataset is None:
         return FSDB(setup_empty_database(db_path=db_path), session_manager=session_manager)
     else:
@@ -599,10 +603,9 @@ def dummy_db(with_scan=False, with_fileset=False, with_file=False):
     --------
     >>> from plantdb.commons.test_database import dummy_db
     >>> db = dummy_db(with_file=True)
-    >>> db.connect()
     INFO     [FSDB] Connected to database successfully
     >>> from plantdb.commons.fsdb.core import get_logged_username
-    >>> get_logged_username(db)  # 'admin' is logged by default
+    >>> get_logged_username(db).username  # 'admin' is logged by default
     'admin'
     >>> print(db.path())  # the database directory
     /tmp/romidb_********
@@ -631,12 +634,10 @@ def dummy_db(with_scan=False, with_fileset=False, with_file=False):
     marker_file = db_path / MARKER_FILE_NAME
     marker_file.open(mode='w').close()
     # Create the FSDB instance and connect
-    db = FSDB(db_path, required_filesets=[], session_manager=SingleSessionManager())
+    db = FSDB(db_path, required_filesets=[], session_manager=NoAuthSessionManager())
     # Flag this instance as a dummy DB so that disconnect will clean up the temp folder
     db._is_dummy = True
     db.connect()
-    # Login as adin to get all the rights (to create and edit)
-    _ = db.login('admin', 'admin')
 
     if with_file:
         # To create a `File`, existing `Scan` & `Fileset` are required

--- a/src/commons/plantdb/commons/test_database.py
+++ b/src/commons/plantdb/commons/test_database.py
@@ -69,6 +69,7 @@ from zipfile import ZipFile
 import requests
 
 from plantdb.commons.auth.session import NoAuthSessionManager
+from plantdb.commons.auth.session import SessionManager
 from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.log import get_logger
 from tqdm import tqdm
@@ -537,8 +538,12 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
 
     Other Parameters
     ----------------
+    no_auth : bool
+        A boolean flag to switch between session managers.
+        If ``True``, use `NoAuthSessionManager` else use `SingleSessionManager`.
     session_manager : SessionManager
         The session manager to use, defaults to ``NoAuthSessionManager``.
+        Override the `no_auth` parameter.
     keep_tmp : bool
         Whether to keep the temporary files. Defaults to ``False``.
     with_configs : bool
@@ -556,7 +561,7 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     Examples
     --------
     >>> from plantdb.commons.test_database import test_database
-    >>> db = test_database()
+    >>> db = test_database(no_auth=True)
     >>> db.connect()
     >>> db.list_scans(owner_only=False)
     ['real_plant_analyzed']
@@ -565,7 +570,17 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     >>> db.disconnect()
     """
     from plantdb.commons.fsdb.core import FSDB
-    session_manager = kwargs.pop('session_manager', NoAuthSessionManager())
+    # Use the 'no_auth' keyword argument to define the correct session manager
+    if kwargs.pop('no_auth', False):
+        session_manager = NoAuthSessionManager()
+    else:
+        session_manager = SingleSessionManager()
+    # If a valid session manager is provided as input, use it
+    in_manager = kwargs.pop('session_manager', None)
+    if in_manager and isinstance(in_manager, SessionManager):
+        session_manager = in_manager
+
+    # Create the test database with selected dataset and session manager
     if dataset is None:
         return FSDB(setup_empty_database(db_path=db_path), session_manager=session_manager)
     else:


### PR DESCRIPTION
## Summary
Introduce a `NoAuthSessionManager` for test and documentation environments, make authentication configurable via the `ROMI_DB_NOAUTH` environment variable, and update related code, Dockerfile, README, and tests.

## Key Changes
- **New Session Manager**
  - Added `NoAuthSessionManager` in `session.py` that always authenticates as the built‑in `admin` user.
  - Provided `admin_token()` helper and comprehensive docstring with usage examples.

- **Core Library Updates**
  - Integrated `NoAuthSessionManager` into `FSDB` core.
  - Simplified `FSDB.__init__` to select `NoAuthSessionManager` when `no_auth=True`.
  - Updated session handling, error messages, and metadata owner comments.
  - Enhanced `get_logged_username` to support both manager types.

- **Docker & Environment Configuration**
  - Added `ROMI_DB_NOAUTH="0"` to `plantdb/docker/Dockerfile` to enforce authentication.
  - Updated README with a “Production ready” section explaining how to enable/disable authentication via the `ROMI_DB_NOAUTH` env var and its precedence.

- **Test Suite Adjustments**
  - Switched test utilities to use `NoAuthSessionManager`.
  - Updated docstrings, example snippets, and comments to reflect the new default manager.
  - Removed unnecessary admin login steps in dummy DB creation.

- **Documentation Fixes**
  - Adjusted Python usage example to fetch the database path via `os.getenv('ROMI_DB')`.
  - Updated various example snippets throughout the codebase.

These changes provide a clearer authentication flow for production, simplify testing without credentials, and improve documentation.