### PR TITLE
Refactor user loading and add temp RBAC for NoAuth

### DIFF
--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -58,6 +58,7 @@ from plantdb.commons.auth.models import Role
 from plantdb.commons.auth.models import TokenUser
 from plantdb.commons.auth.models import User
 from plantdb.commons.log import get_logger
+from plantdb.commons.utils import yes_no_choice
 
 ph = PasswordHasher()
 
@@ -183,11 +184,16 @@ class UserManager(object):
             # Convert to a username indexed dict of User objects
             try:
                 self._parse_user_list(users_list)
-            except Exception as e:
+            except Exception:
                 self.logger.critical(f"Error parsing user list")
-                if 'role' not in users_list[0]:
+                if isinstance(users_list, dict) and 'role' not in list(users_list.values())[0]:
                     self.logger.warning("You are using an outdated user database file")
-                    self.logger.info("Fix it with `scripts/fix_local_fsdb.py`")
+                    if yes_no_choice("Do you want to replace it?", default=True):
+                        pass
+                    else:
+                        raise
+                else:
+                    raise
         return
 
     def _save_users(self) -> None:

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -44,6 +44,7 @@ import os
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -136,6 +137,30 @@ class UserManager(object):
         self.lockout_duration = timedelta(seconds=lockout_duration) if isinstance(lockout_duration,
                                                                                   int) else lockout_duration
 
+    def _load_user_file(self) -> list[dict[str, Any]]:
+        """Load the list of users from the database."""
+        with open(self.users_file, "r") as f:
+            users_list = json.load(f)
+        return users_list
+
+    def _parse_user_list(self, users_list: list[dict[str, Any]]) -> None:
+        """Convert to a username indexed dict of User objects.
+
+        Parameters
+        ----------
+        users_list : list of dict
+            List of user data dictionaries loaded from the JSON persistence file.
+            Each dictionary must contain the keys required by ``User.from_dict``.
+
+        See Also
+        --------
+        plantdb.commons.auth.models.User.from_dict : Class method that creates a `User` from a dict.
+        """
+        for user in users_list:
+            user = User.from_dict(user)
+            self.users[user.username] = user
+        self.logger.debug(f"Loaded {len(self.users)} users from '{self.users_file}'.")
+
     def _load_users(self) -> None:
         """Loads the user database from a JSON file and populates the internal dictionary.
 
@@ -147,22 +172,22 @@ class UserManager(object):
         -----
         The method assumes that the user database file is in JSON format and contains valid user data.
         """
+        self.users = {}
         if not self.users_file.exists():
             self.logger.warning(f"No user database file found under '{self.users_file}'")
-            self.users = {}
         elif self.users_file.stat().st_size == 0:
             self.logger.warning(f"Empty user database file found under '{self.users_file}'")
-            self.users = {}
         else:
             # Load the list of users from the database
-            with open(self.users_file, "r") as f:
-                users_list = json.load(f)
+            users_list = self._load_user_file()
             # Convert to a username indexed dict of User objects
-            self.users = {}
-            for user in users_list:
-                user = User.from_dict(user)
-                self.users[user.username] = user
-            self.logger.debug(f"Loaded {len(self.users)} users from '{self.users_file}'.")
+            try:
+                self._parse_user_list(users_list)
+            except Exception as e:
+                self.logger.critical(f"Error parsing user list")
+                if 'role' not in users_list[0]:
+                    self.logger.warning("You are using an outdated user database file")
+                    self.logger.info("Fix it with `scripts/fix_local_fsdb.py`")
         return
 
     def _save_users(self) -> None:

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -189,7 +189,8 @@ class UserManager(object):
                 if isinstance(users_list, dict) and 'role' not in list(users_list.values())[0]:
                     self.logger.warning("You are using an outdated user database file")
                     if yes_no_choice("Do you want to replace it?", default=True):
-                        pass
+                        # No error raised, the method returns with an empty dictionary for the `users` attribute
+                        self.users = {}  # force an empty users database to trigger the creation of a new user database
                     else:
                         raise
                 else:

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -98,6 +98,7 @@ import json
 import logging
 import os
 import pathlib
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 from shutil import copyfile
@@ -676,10 +677,17 @@ class FSDB(db.DB):
                 f" 'JWTSessionManager' or 'NoAuthSessionManager', got {type(session_manager)}"
             )
 
-        # Initialize RBAC manager with groups file in basedir
-        users_file = basedir / "users.json"
+        if isinstance(self.session_manager, NoAuthSessionManager):
+            # Create a temporary directory with empty to avoid enabling access to real user & groups data
+            manager_dir = Path(tempfile.mkdtemp(prefix='plantdb-'))
+        else:
+            # Will use/create the real users & groups JSON files in basedir
+            manager_dir = basedir
+
+        # Initialize RBAC manager with users & groups files
+        users_file = manager_dir / "users.json"
         users_file.touch(exist_ok=True)  # create the file if missing
-        groups_file = basedir / "groups.json"
+        groups_file = manager_dir / "groups.json"
         groups_file.touch(exist_ok=True)  # create the file if missing
         self.rbac_manager = RBACManager(users_file, groups_file, max_login_attempts, lockout_duration)
 

--- a/src/commons/plantdb/commons/utils.py
+++ b/src/commons/plantdb/commons/utils.py
@@ -304,15 +304,15 @@ def yes_no_choice(question: str, default: bool=True) -> bool:
     --------
     >>> from plantdb.commons.utils import yes_no_choice
     >>> yes_no_choice("Is ROMI an awesome project?")
-    Is ROMI an awesome project? [YES/no]>?
-    Out[3]: True
+    Is ROMI an awesome project? [Y/n]>?
+    True
     >>> yes_no_choice("I am your father!", default=False)
-    I am your father! [yes/NO]>?
-    Out[5]: False
+    I am your father! [y/N]>?
+    False
     """
     opt = {"": default, "yes": True, "y": True, "ye": True, "no": False, "n": False}
-    default_str = "YES" if default else "NO"
-    prompt = f"{question} [{default_str}/{'no' if default else 'yes'}]>"
+    default_choice = " [Y/n]" if default else " [y/N]"
+    prompt = f"{question} {default_choice}"
     while True:
         kbd = input(prompt).strip().lower()
         # Empty input -> take the supplied default

--- a/src/commons/plantdb/commons/utils.py
+++ b/src/commons/plantdb/commons/utils.py
@@ -304,10 +304,10 @@ def yes_no_choice(question: str, default: bool=True) -> bool:
     --------
     >>> from plantdb.commons.utils import yes_no_choice
     >>> yes_no_choice("Is ROMI an awesome project?")
-    Is ROMI an awesome project? [Y/n]>?
+    Is ROMI an awesome project? [Y/n]>
     True
     >>> yes_no_choice("I am your father!", default=False)
-    I am your father! [y/N]>?
+    I am your father! [y/N]>
     False
     """
     opt = {"": default, "yes": True, "y": True, "ye": True, "no": False, "n": False}

--- a/src/commons/plantdb/commons/utils.py
+++ b/src/commons/plantdb/commons/utils.py
@@ -289,3 +289,35 @@ def iso_date_now():
     '2025-09-16T23:39:54.132898'
     """
     return datetime.isoformat(datetime.now())
+
+def yes_no_choice(question: str, default: bool=True) -> bool:
+    """Raise a yes/no question with a default reply and wait for a valid reply from user.
+
+    Parameters
+    ----------
+    question : str
+        The question to ask.
+    default : bool, optional
+        The default answer to the question.
+
+    Examples
+    --------
+    >>> from plantdb.commons.utils import yes_no_choice
+    >>> yes_no_choice("Is ROMI an awesome project?")
+    Is ROMI an awesome project? [YES/no]>?
+    Out[3]: True
+    >>> yes_no_choice("I am your father!", default=False)
+    I am your father! [yes/NO]>?
+    Out[5]: False
+    """
+    opt = {"": default, "yes": True, "y": True, "ye": True, "no": False, "n": False}
+    default_str = "YES" if default else "NO"
+    prompt = f"{question} [{default_str}/{'no' if default else 'yes'}]>"
+    while True:
+        kbd = input(prompt).strip().lower()
+        # Empty input -> take the supplied default
+        if kbd == "":
+            return default
+        if kbd in opt:
+            return opt[kbd]
+        print("Please answer with 'yes' or 'no'.")


### PR DESCRIPTION
- Refactored the user loading process in `manager.py`:
  - Introduced `_load_user_file` to read the persisted JSON file.
  - Added `_parse_user_list` to convert raw dicts into `User` objects and populate `self.users`.
  - Updated `_load_users` to reset the user list, use the new helpers, and log critical errors on parsing failures.
  - Emits a warning for outdated database files with a suggestion to run `scripts/fix_local_fsdb.py`, and handle outdated user files with an optional interactive replacement.
  - Added a new `yes_no_choice` function in `utils.py` for prompting the user with a yes/no question and handling defaults.

- Added temporary RBAC configuration handling for `NoAuthSessionManager`:
  - When using `NoAuthSessionManager`, a temporary directory is created via `tempfile.mkdtemp()` and assigned to `manager_dir`.
  - The temporary directory is used for both `users_file` and `groups_file`, isolating RBAC data for unauthenticated sessions while other managers continue using the standard `basedir`.