### PR TITLE
Organize docs, improve installation guide, fix docstrings

### DIFF
--- a/docs/plantdb_sync.md
+++ b/docs/plantdb_sync.md
@@ -26,7 +26,7 @@ Call the entrypoint:
 sync_app
 ```
 
-You amy also run the synchronization tool using Python:
+You may also run the synchronization tool using Python:
 ```shell
 python -m plantdb.client.sync_app
 ```

--- a/docs/rest_api/index.md
+++ b/docs/rest_api/index.md
@@ -1,0 +1,18 @@
+# REST API
+
+Welcome to the PlantDB REST API!
+
+This interface provides programmatic access to plant scan datasets, images, point clouds, meshes, and related metadata.
+Use the API to list scans, retrieve files, and manage data directly from your applications.
+
+- **Quick start**: Run `python fsdb_rest_api.py --test` to launch a temporary server.
+- **Core endpoints**: `/scans`, `/scan/<id>`, `/image/...`, `/pointcloud/...`, `/mesh/...`.
+- **Management**:
+    - Register users via `/register`
+    - Obtain JWT tokens via `/login`
+    - Create new scans via `/api/scan`
+
+## Table of Contents
+
+- [How to Run the REST API](rest_api_usage.md): for detailed usage instructions
+- [REST API Endpoints](rest_api_endpoints.md): for a full endpoint reference

--- a/docs/rest_api/rest_api_endpoints.md
+++ b/docs/rest_api/rest_api_endpoints.md
@@ -1,10 +1,11 @@
-# PlantDB REST API Documentation
+# REST API Endpoints
 
 This document describes the REST API endpoints for the PlantDB (Plant Database) system, which provides access to plant scan datasets, images, point clouds, meshes, and related data through RESTful endpoints.
 
 ## Overview
 
-The PlantDB REST API is implemented using Flask and Flask-RESTful, providing a comprehensive interface for managing and accessing plant-related datasets. The Python implementation is located in the `plantdb.server.rest_api` module, and the CLI server is started using `fsdb_rest_api.py`.
+The PlantDB REST API is implemented using Flask and Flask-RESTful, providing a comprehensive interface for managing and accessing plant-related datasets. The Python implementation is located in the
+`plantdb.server.rest_api` module, and the CLI server is started using `fsdb_rest_api.py`.
 
 **Base URL**: `http://127.0.0.1:5000` (default, configurable)
 
@@ -26,85 +27,91 @@ The PlantDB REST API is implemented using Flask and Flask-RESTful, providing a c
 
 ### Starting the Server
 
+To run the server with a temporary test database:
 ```bash
-# Start with default settings
-python fsdb_rest_api.py --db_location /path/to/database
-
-# Start with custom host and port
-python fsdb_rest_api.py --db_location /path/to/database --host 0.0.0.0 --port 8080
-
-# Start in debug mode
-python fsdb_rest_api.py --db_location /path/to/database --debug
-
-# Start with test database
-python fsdb_rest_api.py --test --debug
+python fsdb_rest_api.py --test
 ```
+
+For more explanations, have a look at [how to run the REST API](rest_api_usage.md).
 
 ### Authentication
 
-Some endpoints require authentication. Use the `/register` and `/login` endpoints to obtain authentication tokens.
+Some endpoints require authentication.
+Use the `/register` and `/login` endpoints to obtain authentication tokens.
 
 ---
 
 ## Core Dataset Endpoints
 
 ### GET `/`
+
 **Home endpoint**
+
 - **Description**: Returns basic API information
 - **Response**: Welcome message and API status
 
 ### GET `/scans`
+
 **List all scans**
+
 - **Description**: Retrieve a list of all available scan datasets
-- **Query Parameters**: 
-  - `filterQuery` (optional): Filter scans based on metadata content
+- **Query Parameters**:
+    - `filterQuery` (optional): Filter scans based on metadata content
 - **Response**: JSON array of scan summaries
-- **Examples**: 
-  - All scans: `GET /scans`
-  - Filtered: `GET /scans?filterQuery=arabidopsis`
+- **Examples**:
+    - All scans: `GET /scans`
+    - Filtered: `GET /scans?filterQuery=arabidopsis`
 
 ### GET `/scans_info`
+
 **Scan information table**
+
 - **Description**: Get comprehensive scan information in tabular format
-- **Query Parameters**: 
-  - `filterQuery` (optional): Filter scans
+- **Query Parameters**:
+    - `filterQuery` (optional): Filter scans
 - **Response**: JSON object with detailed scan metadata, file counts, and task status
 - **Example**: `GET /scans_info`
 
 ### GET `/scans/<scan_id>`
+
 **Individual scan details**
+
 - **Description**: Get detailed information about a specific scan dataset
-- **Path Parameters**: 
-  - `scan_id`: Unique identifier of the scan
+- **Path Parameters**:
+    - `scan_id`: Unique identifier of the scan
 - **Response**: JSON object with comprehensive scan details including camera parameters, poses, and file URIs
 - **Examples**:
-  - `GET /scans/real_plant_analyzed`
-  - `GET /scans/virtual_plant_analyzed`
+    - `GET /scans/real_plant_analyzed`
+    - `GET /scans/virtual_plant_analyzed`
 
 !!! warning "Dependency"
-    This endpoint requires the `Colmap` task to be completed. Returns HTTP 500 if missing.
+This endpoint requires the `Colmap` task to be completed. Returns HTTP 500 if missing.
 
 ---
 
 ## File Access Endpoints
 
 ### GET `/files/<path>`
+
 **Direct file access**
+
 - **Description**: Retrieve any file from the database using its path
-- **Path Parameters**: 
-  - `path`: Full path to the file within the database
+- **Path Parameters**:
+    - `path`: Full path to the file within the database
 - **Response**: File content (binary or text)
 - **Examples**:
-  - Image: `GET /files/real_plant_analyzed/images/00000_rgb.jpg`
-  - Metadata: `GET /files/real_plant_analyzed/metadata/metadata.json`
+    - Image: `GET /files/real_plant_analyzed/images/00000_rgb.jpg`
+    - Metadata: `GET /files/real_plant_analyzed/metadata/metadata.json`
 
 ### POST `/files/<scan_id>`
+
 **Upload file to dataset**
+
 - **Description**: Upload a new file to a specific scan dataset
-- **Path Parameters**: 
-  - `scan_id`: Target scan identifier
-- **Form Data**: 
-  - `file_upload`: The file to upload
+- **Path Parameters**:
+    - `scan_id`: Target scan identifier
+- **Form Data**:
+    - `file_upload`: The file to upload
 - **Response**: Upload confirmation
 - **Example**:
   ```bash
@@ -112,80 +119,94 @@ Some endpoints require authentication. Use the `/register` and `/login` endpoint
   ```
 
 ### GET `/archive/<scan_id>`
+
 **Download dataset archive**
+
 - **Description**: Download a complete dataset as a ZIP file
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier to archive
+- **Path Parameters**:
+    - `scan_id`: Scan identifier to archive
 - **Response**: ZIP file containing the entire dataset
 - **Examples**:
-  - `GET /archive/real_plant_analyzed`
-  - `GET /archive/virtual_plant_analyzed`
+    - `GET /archive/real_plant_analyzed`
+    - `GET /archive/virtual_plant_analyzed`
 
 ---
 
 ## Specialized Data Endpoints
 
 ### GET `/image/<scan_id>/<fileset_id>/<file_id>`
+
 **Access images with resizing**
+
 - **Description**: Retrieve images with optional resizing
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
-  - `fileset_id`: Fileset identifier (usually 'images')
-  - `file_id`: Image file identifier (without extension)
-- **Query Parameters**: 
-  - `size`: Image size - `orig` (original), `large`, `thumb` (thumbnail)
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
+    - `fileset_id`: Fileset identifier (usually 'images')
+    - `file_id`: Image file identifier (without extension)
+- **Query Parameters**:
+    - `size`: Image size - `orig` (original), `large`, `thumb` (thumbnail)
 - **Response**: Image file (JPEG/PNG)
 - **Examples**:
-  - Thumbnail: `GET /image/real_plant_analyzed/images/00000_rgb`
-  - Original: `GET /image/real_plant_analyzed/images/00000_rgb?size=orig`
-  - Large: `GET /image/real_plant_analyzed/images/00000_rgb?size=large`
+    - Thumbnail: `GET /image/real_plant_analyzed/images/00000_rgb`
+    - Original: `GET /image/real_plant_analyzed/images/00000_rgb?size=orig`
+    - Large: `GET /image/real_plant_analyzed/images/00000_rgb?size=large`
 
 ### GET `/pointcloud/<scan_id>/<fileset_id>/<file_id>`
+
 **Access point clouds**
+
 - **Description**: Retrieve point cloud files with optional voxel size control
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
-  - `fileset_id`: Point cloud fileset identifier
-  - `file_id`: Point cloud file identifier
-- **Query Parameters**: 
-  - `size`: `orig` (original), `preview`, or a float value for voxel size
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
+    - `fileset_id`: Point cloud fileset identifier
+    - `file_id`: Point cloud file identifier
+- **Query Parameters**:
+    - `size`: `orig` (original), `preview`, or a float value for voxel size
 - **Response**: Point cloud file (PLY format)
 - **Examples**:
-  - Preview: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud`
-  - Original: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=orig`
-  - Custom voxel: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=2.3`
+    - Preview: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud`
+    - Original: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=orig`
+    - Custom voxel: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=2.3`
 
 ### GET `/pcGroundTruth/<scan_id>/<fileset_id>/<file_id>`
+
 **Access ground truth point clouds**
+
 - **Description**: Retrieve ground truth point cloud files
 - **Parameters**: Same as `/pointcloud` endpoint
 - **Response**: Ground truth point cloud file (PLY format)
 
 ### GET `/mesh/<scan_id>/<fileset_id>/<file_id>`
+
 **Access 3D meshes**
+
 - **Description**: Retrieve 3D mesh files
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
-  - `fileset_id`: Mesh fileset identifier
-  - `file_id`: Mesh file identifier
-- **Query Parameters**: 
-  - `size`: Currently only `orig` (original) supported
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
+    - `fileset_id`: Mesh fileset identifier
+    - `file_id`: Mesh file identifier
+- **Query Parameters**:
+    - `size`: Currently only `orig` (original) supported
 - **Response**: Mesh file (PLY format)
 - **Example**: `GET /mesh/real_plant_analyzed/TriangleMesh_9_most_connected_t_open3d_00e095c359/TriangleMesh`
 
 ### GET `/skeleton/<scan_id>`
+
 **Access curve skeleton data**
+
 - **Description**: Retrieve curve skeleton information for a scan
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 - **Response**: JSON with curve skeleton data
 - **Example**: `GET /skeleton/real_plant_analyzed`
 
 ### GET `/sequence/<scan_id>`
+
 **Access sequence information**
+
 - **Description**: Retrieve sequence-related information for a scan
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 - **Response**: JSON with sequence data
 - **Example**: `GET /sequence/real_plant_analyzed`
 
@@ -194,7 +215,9 @@ Some endpoints require authentication. Use the `/register` and `/login` endpoint
 ## Database Management
 
 ### GET `/refresh`
+
 **Refresh scan database**
+
 - **Description**: Refresh the list of scans in the database
 - **Response**: HTTP 200 on completion
 - **Example**: `GET /refresh`
@@ -206,43 +229,59 @@ Some endpoints require authentication. Use the `/register` and `/login` endpoint
 The following endpoints provide programmatic access to create and manage database content:
 
 ### POST `/api/scan`
+
 **Create new scan**
+
 - **Description**: Create a new scan dataset
 - **Request Body**: JSON with scan metadata
 - **Response**: Scan creation confirmation
 
 ### GET/POST `/api/scan/<scan_id>/metadata`
+
 **Manage scan metadata**
+
 - **Description**: Get or update scan metadata
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 
 ### GET `/api/scan/<scan_id>/filesets`
+
 **List scan filesets**
+
 - **Description**: List all filesets within a scan
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 
 ### POST `/api/fileset`
+
 **Create new fileset**
+
 - **Description**: Create a new fileset within a scan
 - **Request Body**: JSON with fileset information
 
 ### GET/POST `/api/fileset/<scan_id>/<fileset_id>/metadata`
+
 **Manage fileset metadata**
+
 - **Description**: Get or update fileset metadata
 
 ### GET `/api/fileset/<scan_id>/<fileset_id>/files`
+
 **List fileset files**
+
 - **Description**: List all files within a fileset
 
 ### POST `/api/file`
+
 **Create new file**
+
 - **Description**: Add a new file to a fileset
 - **Request Body**: File data and metadata
 
 ### GET/POST `/api/file/<scan_id>/<fileset_id>/<file_id>/metadata`
+
 **Manage file metadata**
+
 - **Description**: Get or update file metadata
 
 ---
@@ -250,7 +289,9 @@ The following endpoints provide programmatic access to create and manage databas
 ## Health and Status
 
 ### GET `/health`
+
 **Health check**
+
 - **Description**: Check API server health and database connectivity
 - **Response**: JSON with health status information
 - **Example**: `GET /health`
@@ -298,6 +339,7 @@ Information returned by `/scans` endpoint:
 Information returned by `/scans/<scan_id>` includes all summary fields plus:
 
 #### Camera Model
+
 ```json
 {
   "camera": {
@@ -306,24 +348,50 @@ Information returned by `/scans/<scan_id>` includes all summary fields plus:
       "model": "OPENCV",
       "width": 1440,
       "height": 1080,
-      "params": [1166.95, 1166.95, 720, 540, -0.0014, -0.0014, 0, 0]
+      "params": [
+        1166.95,
+        1166.95,
+        720,
+        540,
+        -0.0014,
+        -0.0014,
+        0,
+        0
+      ]
     }
   }
 }
 ```
 
 #### Camera Poses
+
 ```json
 {
   "camera": {
     "poses": [
       {
         "id": 1,
-        "tvec": [369.43, 120.36, -62.07],
+        "tvec": [
+          369.43,
+          120.36,
+          -62.07
+        ],
         "rotmat": [
-          [0.0648, -0.9972, 0.0382],
-          [-0.3390, -0.0580, -0.9390],
-          [0.9385, 0.0479, -0.3418]
+          [
+            0.0648,
+            -0.9972,
+            0.0382
+          ],
+          [
+            -0.3390,
+            -0.0580,
+            -0.9390
+          ],
+          [
+            0.9385,
+            0.0479,
+            -0.3418
+          ]
         ],
         "photoUri": "/files/scan_id/images/00000_rgb.jpg",
         "thumbnailUri": "/files/scan_id/images/00000_rgb?size=thumb",
@@ -335,12 +403,22 @@ Information returned by `/scans/<scan_id>` includes all summary fields plus:
 ```
 
 #### Reconstruction Workspace
+
 ```json
 {
   "workspace": {
-    "x": [340, 440],
-    "y": [330, 410], 
-    "z": [-180, 105]
+    "x": [
+      340,
+      440
+    ],
+    "y": [
+      330,
+      410
+    ],
+    "z": [
+      -180,
+      105
+    ]
   }
 }
 ```

--- a/docs/rest_api/rest_api_usage.md
+++ b/docs/rest_api/rest_api_usage.md
@@ -1,0 +1,139 @@
+# How to Run the REST API
+
+Below is a quick‑start guide that covers the most common ways to launch the **PlantDB REST API**.  
+All the commands work on any platform where Python 3.10+ is available and the `plantdb.server` package has been installed (_e.g._ via `pip install plantdb.server` or from source).
+
+## Core concepts
+
+| Concept                    | What it is                                                                     | Where to configure it                                            |
+|----------------------------|--------------------------------------------------------------------------------|------------------------------------------------------------------|
+| **Database location**      | Path to the local FSDB that stores scans, images, point clouds, etc.           | `ROMI_DB` environment variable **or** `--db_location` CLI option |
+| **API URL prefix**         | Optional prefix (_e.g._ `/api/v1`) that will be added in front of every endpoint | `PLANTDB_API_PREFIX` env‑var (used by the WSGI entry‑point)      |
+| **SSL**                    | Enforce HTTPS‑only cookies (important when the server is exposed publicly)     | `PLANTDB_API_SSL=true`                                           |
+| **Authentication secrets** | Randomly generated if omitted; control session and JWT handling                | `FLASK_SECRET_KEY` and `JWT_SECRET_KEY`                          |
+| **Session limits**         | Maximum concurrent sessions, JWT lifetime, refresh token TTL                   | `MAX_SESSION`, `SESSION_TIMEOUT`, `REFRESH_TIMEOUT`              |
+| **Proxy support**          | Required when the service sits behind a reverse proxy (_e.g._ Nginx, uWSGI)      | `--proxy` flag (CLI)                                             |
+
+All of the above are documented in the module doc‑strings of **`fsdb_rest_api.py`** (the CLI) and **`wsgi.py`** (the WSGI entry point).
+
+## Test mode – Play with a temporary toy dataset
+
+If you just want to explore the API without touching any real data, start the server in **test mode**.
+A temporary database (populated with a small sample dataset) is created automatically and removed when the process exits.
+
+```shell
+python fsdb_rest_api.py --test --debug
+```
+
+| Option                  | Effect                                                                 |
+|-------------------------|------------------------------------------------------------------------|
+| `--test`                | Builds a temporary FSDB (includes sample scans, images, point clouds). |
+| `--debug`               | Runs Flask’s built‑in debugger (auto‑reload, detailed error pages).    |
+| `--empty` *(optional)*  | Skip loading the sample dataset – you get an **empty** database.       |
+| `--models` *(optional)* | Add pre‑trained CNN models to the temporary DB (useful for ML demos).  |
+
+The server will listen on `0.0.0.0:5000` by default, which you can reach at **`http://localhost:5000/`**.
+
+## Development – Run against a real local FSDB
+
+When you have an existing PlantDB directory that you want to expose, start the server with explicit host/port settings:
+
+```shell
+python fsdb_rest_api.py \
+    --db_location /path/to/your/database \
+    --host 127.0.0.1 \
+    --port 8080 \
+    --debug          # optional: turn on Flask debug mode
+```
+
+**Key CLI flags**
+
+| Flag            | Description                                                                                      |
+|-----------------|--------------------------------------------------------------------------------------------------|
+| `--db_location` | Path to the FSDB you wish to serve. If omitted, the environment variable `ROMI_DB` is consulted. |
+| `--host`        | Network interface to bind (default `0.0.0.0`).                                                   |
+| `--port`        | TCP port (default `5000`).                                                                       |
+| `--proxy`       | Tell the app it is behind a reverse proxy; the server will respect the `X‑Forwarded-*` headers.  |
+| `--log-level`   | Choose among `debug`, `info`, `warning`, `error`, `critical` (defaults to `INFO`).               |
+
+**Example**: Behind a reverse proxy (e.g. Nginx)
+
+```shell
+python fsdb_rest_api.py \
+    --db_location /data/plantdb \
+    --host 127.0.0.1 \
+    --port 5000 \
+    --proxy
+```
+
+The proxy will forward requests to `127.0.0.1:5000`; the app will automatically strip the proxy prefix (if set via
+`PLANTDB_API_PREFIX`) and generate correct URLs in responses.
+
+
+## Production – Deploy with a WSGI server (uWSGI, Gunicorn)
+
+For a robust, multi‑process deployment you typically use a dedicated WSGI server.
+The **`wsgi.py`** module provides the ready‑to‑import `application` object:
+
+```shell
+uwsgi --http :5000 \
+      --module plantdb.server.cli.wsgi:application \
+      --callable application \
+      --master
+```
+
+| Parameter                                      | Meaning                                                      |
+|------------------------------------------------|--------------------------------------------------------------|
+| `--http :5000`                                 | Expose the service on port 5000 (change as needed).          |
+| `--module plantdb.server.cli.wsgi:application` | Import the WSGI entry point.                                 |
+| `--callable application`                       | The Flask app instance created by `rest_api()`.              |
+| `--master`                                     | Run uWSGI in master mode (recommended for graceful reloads). |
+
+**Environment variables** (set before starting uWSGI) let you customise the deployment without touching code:
+
+```shell
+export ROMI_DB=/srv/plantdb
+export PLANTDB_API_PREFIX=/api/v1
+export PLANTDB_API_SSL=true          # enforce HTTPS‑only cookies
+export FLASK_SECRET_KEY=myflasksecret
+export JWT_SECRET_KEY=myjwtsecret
+export SESSION_TIMEOUT=1800         # 30 min
+export REFRESH_TIMEOUT=86400        # 1 day
+export MAX_SESSION=20               # up to 20 concurrent users
+```
+
+The server will then be reachable at **`https://<host>:5000/api/v1/`** (or without the prefix if you leave
+`PLANTDB_API_PREFIX` empty).
+
+## Quick reference of the most useful endpoints
+
+| Endpoint                                       | Method           | Description                                      |
+|------------------------------------------------|------------------|--------------------------------------------------|
+| `/`                                            | `GET`            | Health check & basic landing page.               |
+| `/health`                                      | `GET`            | Detailed service health (database connectivity). |
+| `/scans`                                       | `GET`            | List all scans (optionally filter by owner).     |
+| `/scans_info`                                  | `GET`            | Tabular view with additional metadata.           |
+| `/scan/<scan_id>`                              | `GET/PUT/DELETE` | CRUD operations on a single scan.                |
+| `/scan/<scan_id>/filesets`                     | `GET/POST`       | List or create filesets belonging to a scan.     |
+| `/file/<scan_id>/<fileset_id>/<file_id>`       | `GET/PUT/DELETE` | Access or modify a concrete file.                |
+| `/image/<scan_id>/<fileset_id>/<file_id>`      | `GET`            | Retrieve an image asset.                         |
+| `/pointcloud/<scan_id>/<fileset_id>/<file_id>` | `GET`            | Retrieve a point‑cloud asset.                    |
+| `/mesh/<scan_id>/<fileset_id>/<file_id>`       | `GET`            | Retrieve a mesh asset.                           |
+| `/register`                                    | `POST`           | Create a new user account.                       |
+| `/login`                                       | `POST`           | Obtain a JWT access token.                       |
+| `/logout`                                      | `POST`           | Invalidate the current JWT.                      |
+| `/token-refresh`                               | `POST`           | Refresh an access token using a refresh token.   |
+| `/create-api-token`                            | `POST`           | Generate a long‑lived API token (for scripts).   |
+
+All routes respect the optional **URL prefix** (
+`PLANTDB_API_PREFIX`) and enforce JWT authentication when the corresponding resource requires it.
+
+## Common troubleshooting tips
+
+| Symptom                                              | Likely cause                                                                                  | Fix                                                                                                                                             |
+|------------------------------------------------------|-----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| **“No secret key was provided”** warnings on startup | Environment variables `FLASK_SECRET_KEY` / `JWT_SECRET_KEY` not set.                          | Either export those variables or let the server generate a random 64‑bit secret (the warning can be ignored for local testing).                 |
+| **“Connecting to local plant database …” fails**     | Wrong `ROMI_DB` path or missing read permissions.                                             | Verify the path exists and is readable; set `ROMI_DB` correctly or use `--db_location`.                                                         |
+| **All endpoints return 404**                         | The server is running behind a proxy but `--proxy` flag (or `PLANTDB_API_PREFIX`) is not set. | Restart with `--proxy` and/or configure `PLANTDB_API_PREFIX`.                                                                                   |
+| **CORS errors from a web front‑end**                 | Cross‑origin requests blocked.                                                                | The Flask app enables CORS globally; ensure the browser is not caching old headers, or restrict origins via Flask‑CORS configuration if needed. |
+| **SSL not enforced**                                 | `PLANTDB_API_SSL` is not true, or cookies are still sent over HTTP.                           | Set `PLANTDB_API_SSL=true` and serve the app via HTTPS (e.g., terminate TLS at the reverse proxy).                                              |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,10 @@ repo_url: https://github.com/romi/plantdb
 nav:
   - 'Home': index.md
   - 'PlantDB Sync UI': plantdb_sync.md
-  - 'REST API': rest_api.md
+  - 'REST API':
+    - rest_api/index.md
+    - rest_api/rest_api_usage.md
+    - rest_api/rest_api_endpoints.md
   - 'Reference API': reference/
   - 'Developers' :
     - 'Release Guide': developers/releases.md

--- a/src/client/plantdb/client/api_endpoints.py
+++ b/src/client/plantdb/client/api_endpoints.py
@@ -417,8 +417,6 @@ def fileset(scan_id, fileset_id, **kwargs) -> str:
         The name of the scan to access.
     fileset_id : str
         The name of the fileset to access.
-    file_id : str
-        The name of the file to access.
 
     Other Parameters
     ----------------

--- a/src/commons/plantdb/commons/auth/rbac.py
+++ b/src/commons/plantdb/commons/auth/rbac.py
@@ -60,7 +60,7 @@ def requires_permission(required_permissions: Union[Permission, List[Permission]
 
     Parameters
     ----------
-    required_permission:  Union[Permission, List[Permission]]
+    required_permissions: Union[Permission, List[Permission]]
         A single permission string or list of permission that the user must have to access the decorated method.
     """
 

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -747,12 +747,12 @@ class JWTSessionManager(SessionManager):
             The maximum number of concurrent sessions to allow.
             Defaults to ``10``.
         secret_key : str | bytes | None
-           Secret used for HS512 signing of JWTs.
-           - If a ``bytes`` object is supplied, it must be ≥ 64 bytes.
-           - If a ``str`` (pass‑phrase) is supplied, it will be stretched with Argon2 to produce a 64‑byte key.
-           - If ``None`` (default) a fresh random 64‑byte key is generated.
-             This will break the API tokens persistence across restarts as, after a restart, the new instance
-             gets a different secret key, so all previously persisted API tokens in the file become unverifiable.
+            Secret used for HS512 signing of JWTs.
+            - If a ``bytes`` object is supplied, it must be ≥ 64 bytes.
+            - If a ``str`` (pass‑phrase) is supplied, it will be stretched with Argon2 to produce a 64‑byte key.
+            - If ``None`` (default) a fresh random 64‑byte key is generated.
+              This will break the API tokens persistence across restarts as, after a restart, the new instance
+              gets a different secret key, so all previously persisted API tokens in the file become unverifiable.
         leeway : int, optional
             Allowed leeway, in seconds, after tokens expiration date, to accommodate for clock-skew.
             Set it to `0` so that the token is considered expired immediately after its exp claim passes.

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -10,6 +10,7 @@ Server-side component of the ROMI plant database system.
 Provides a robust REST API server implementation for managing plant phenotyping data.
 
 Features include:
+
 - File system database management
 - Data synchronization services
 - Command-line tools for database management
@@ -33,19 +34,84 @@ API documentation for the `plantdb` library is available at: [https://romi.githu
 
 We strongly recommend using isolated environments to install ROMI libraries.
 
+### Python venv
+
+To create a new Python virtual environment for PlantDB:
+
+```shell
+python -m venv .venv         # create a pyvenv named `.venv` in the current directory
+source .venv/bin/activate    # activate the virtual environment
+pip install ipython          # optional interactive workbench
+```
+
+### Conda
+
 This documentation uses `conda` as both an environment and package manager.
-If you don't have`miniconda3` installed, please refer to the [official documentation](https://docs.conda.io/en/latest/miniconda.html).
+If you don't have `miniconda3` installed, please refer to the [official documentation](https://docs.conda.io/en/latest/miniconda.html).
 
 To create a new conda environment for PlantDB:
+
 ``` shell
 conda create -n plantdb 'python=3.10' ipython
 ```
 
+To use it, you need to activate it with:
+
+```shell
+conda activate plantdb  # activate your environment
+```
+
 ## Installation
+
+### User – Pre Built Packages
 
 Activate your environment and install the packages using `pip`:
 
 ``` shell
-conda activate plantdb  # activate your environment first!
 pip install plantdb.commons plantdb.server plantdb.client
 ```
+
+### Developers – From Sources
+
+To contribute to the development, you will need to install the sources:
+
+```shell
+git clone https://github.com/romi/plantdb.git
+cd plantdb
+# Install 'plantdb.commons'...
+pip install -e src/commons/.[io]
+# Install 'plantdb.server'...
+pip install -e src/server/.
+# Install 'plantdb.client'...
+pip install -e src/client/
+```
+
+## Usage
+
+### Test with Toy Dataset
+
+To run the server with a temporary test database in debug mode:
+
+```shell
+python fsdb_rest_api.py --test --debug
+```
+
+### Development
+
+To start the REST API server for a local plant database:
+
+```shell
+python fsdb_rest_api.py --db_location /path/to/your/database --host 127.0.0.1 --port 8080
+```
+
+### Production
+
+To start the REST API server in production:
+
+```shell
+uwsgi --http :5000 --module plantdb.server.cli.wsgi:application --callable application --master
+```
+
+For detailed usage instructions and a full endpoint reference, see:
+ - [How to Run the REST API](https://romi.github.io/plantdb/site/rest_api/rest_api_usage/)
+ - [REST API Endpoints](https://romi.github.io/plantdb/site/rest_api/rest_api_endpoints/)


### PR DESCRIPTION
### Summary
- Split REST API documentation into separate pages (`index`, `usage`, `endpoints`) and updated navigation in `mkdocs.yml`.
- Added a comprehensive installation and usage guide to `README.md` with virtual environment, Conda, package installation, and server run examples.
- Fixed docstring typo: corrected `required_permission` to `required_permissions` in `rbac.py`.
- Cleaned up `secret_key` docstring formatting in `session.py`.
- Removed obsolete `file_id` parameter documentation from `api_endpoints.py`.