### PR TITLE
Add interactive cleanup, no‑auth, and generic lock manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![ROMI_logo](docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / plantdb
+# [![ROMI_logo](https://github.com/romi/plantdb/blob/ab29155f0bc0ad755c3455c4db3eb56c4bbd1b0e/docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / plantdb
 
 [![Licence](https://img.shields.io/github/license/romi/plantdb?color=lightgray)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 [![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fromi%2Fplantdb%2Frefs%2Fheads%2Fdev%2Fsrc%2Fcommons%2Fpyproject.toml&logo=python&logoColor=white)]()

--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ docker run -p 5000:5000 -v $ROMI_DB:/myapp/db -it roboticsmicrofarms/plantdb
 
 **Obviously, you have to install docker first!**
 
+### Production ready
+
+If you want to set up a database for multiple users and want to **secure it by enabling authentication**, you must secure it by setting a `.env` at its root directory as follows:
+```dotenv
+ROMI_DB_NOAUTH="0"
+```
+Or set it as an environment variable if you prefer, as done in our distributed docker image.
+Any system-wide environment variable will take precedence over variables in the `.env` file.
+
 ## Usage
 
 ### Python API
@@ -186,13 +195,12 @@ docker run -p 5000:5000 -v $ROMI_DB:/myapp/db -it roboticsmicrofarms/plantdb
 Here is a minimal example how to use the `plantdb` library in Python:
 
 ```python
-# Get the environment variable $ROMI_DB
 import os
-
-db_path = os.environ['ROMI_DB']
-# Use it to connect to DB:
 from plantdb.commons.fsdb.core import FSDB
 
+# Get the environment variable $ROMI_DB
+db_path = os.getenv('ROMI_DB')
+# Use it to connect to DB:
 db = FSDB(db_path)
 db.connect()
 # Access to a dataset named `real_plant` (from the example database)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,6 +100,8 @@ ENV DEB_PYTHON_INSTALL_LAYOUT=deb_system
 ENV PLANTDB_API_PREFIX=""
 # Location of the database folder to serve:
 ENV ROMI_DB="/myapp/db"
+# Force credentials usage on this database
+ENV ROMI_DB_NOAUTH="0"
 
 # Change Shell to 'bash', default is 'sh':
 SHELL ["/bin/bash", "-c"]

--- a/docs/developers/releases.md
+++ b/docs/developers/releases.md
@@ -61,7 +61,7 @@ git flow release start X.Y.Z
    # Version X.Y.Z - YYYY-MM-DD
       - Description of the first change
       - Description of the second change
-      - …
+      - ...
    ```
 
 2. Update version numbers in TOML files:
@@ -128,7 +128,7 @@ git checkout -b release/X.Y.Z dev
    # Version X.Y.Z - YYYY-MM-DD
       - Description of the first change
       - Description of the second change
-      - …
+      - ...
    ```
 
 2. Update version numbers in TOML files:

--- a/docs/plantdb_sync.md
+++ b/docs/plantdb_sync.md
@@ -26,7 +26,7 @@ Call the entrypoint:
 sync_app
 ```
 
-You amy also run the synchronization tool using Python:
+You may also run the synchronization tool using Python:
 ```shell
 python -m plantdb.client.sync_app
 ```

--- a/docs/rest_api/index.md
+++ b/docs/rest_api/index.md
@@ -1,0 +1,18 @@
+# REST API
+
+Welcome to the PlantDB REST API!
+
+This interface provides programmatic access to plant scan datasets, images, point clouds, meshes, and related metadata.
+Use the API to list scans, retrieve files, and manage data directly from your applications.
+
+- **Quick start**: Run `python fsdb_rest_api.py --test` to launch a temporary server.
+- **Core endpoints**: `/scans`, `/scan/<id>`, `/image/...`, `/pointcloud/...`, `/mesh/...`.
+- **Management**:
+    - Register users via `/register`
+    - Obtain JWT tokens via `/login`
+    - Create new scans via `/api/scan`
+
+## Table of Contents
+
+- [How to Run the REST API](rest_api_usage.md): for detailed usage instructions
+- [REST API Endpoints](rest_api_endpoints.md): for a full endpoint reference

--- a/docs/rest_api/rest_api_endpoints.md
+++ b/docs/rest_api/rest_api_endpoints.md
@@ -1,10 +1,11 @@
-# PlantDB REST API Documentation
+# REST API Endpoints
 
 This document describes the REST API endpoints for the PlantDB (Plant Database) system, which provides access to plant scan datasets, images, point clouds, meshes, and related data through RESTful endpoints.
 
 ## Overview
 
-The PlantDB REST API is implemented using Flask and Flask-RESTful, providing a comprehensive interface for managing and accessing plant-related datasets. The Python implementation is located in the `plantdb.server.rest_api` module, and the CLI server is started using `fsdb_rest_api.py`.
+The PlantDB REST API is implemented using Flask and Flask-RESTful, providing a comprehensive interface for managing and accessing plant-related datasets. The Python implementation is located in the
+`plantdb.server.rest_api` module, and the CLI server is started using `fsdb_rest_api.py`.
 
 **Base URL**: `http://127.0.0.1:5000` (default, configurable)
 
@@ -26,85 +27,91 @@ The PlantDB REST API is implemented using Flask and Flask-RESTful, providing a c
 
 ### Starting the Server
 
+To run the server with a temporary test database:
 ```bash
-# Start with default settings
-python fsdb_rest_api.py --db_location /path/to/database
-
-# Start with custom host and port
-python fsdb_rest_api.py --db_location /path/to/database --host 0.0.0.0 --port 8080
-
-# Start in debug mode
-python fsdb_rest_api.py --db_location /path/to/database --debug
-
-# Start with test database
-python fsdb_rest_api.py --test --debug
+python fsdb_rest_api.py --test
 ```
+
+For more explanations, have a look at [how to run the REST API](rest_api_usage.md).
 
 ### Authentication
 
-Some endpoints require authentication. Use the `/register` and `/login` endpoints to obtain authentication tokens.
+Some endpoints require authentication.
+Use the `/register` and `/login` endpoints to obtain authentication tokens.
 
 ---
 
 ## Core Dataset Endpoints
 
 ### GET `/`
+
 **Home endpoint**
+
 - **Description**: Returns basic API information
 - **Response**: Welcome message and API status
 
 ### GET `/scans`
+
 **List all scans**
+
 - **Description**: Retrieve a list of all available scan datasets
-- **Query Parameters**: 
-  - `filterQuery` (optional): Filter scans based on metadata content
+- **Query Parameters**:
+    - `filterQuery` (optional): Filter scans based on metadata content
 - **Response**: JSON array of scan summaries
-- **Examples**: 
-  - All scans: `GET /scans`
-  - Filtered: `GET /scans?filterQuery=arabidopsis`
+- **Examples**:
+    - All scans: `GET /scans`
+    - Filtered: `GET /scans?filterQuery=arabidopsis`
 
 ### GET `/scans_info`
+
 **Scan information table**
+
 - **Description**: Get comprehensive scan information in tabular format
-- **Query Parameters**: 
-  - `filterQuery` (optional): Filter scans
+- **Query Parameters**:
+    - `filterQuery` (optional): Filter scans
 - **Response**: JSON object with detailed scan metadata, file counts, and task status
 - **Example**: `GET /scans_info`
 
 ### GET `/scans/<scan_id>`
+
 **Individual scan details**
+
 - **Description**: Get detailed information about a specific scan dataset
-- **Path Parameters**: 
-  - `scan_id`: Unique identifier of the scan
+- **Path Parameters**:
+    - `scan_id`: Unique identifier of the scan
 - **Response**: JSON object with comprehensive scan details including camera parameters, poses, and file URIs
 - **Examples**:
-  - `GET /scans/real_plant_analyzed`
-  - `GET /scans/virtual_plant_analyzed`
+    - `GET /scans/real_plant_analyzed`
+    - `GET /scans/virtual_plant_analyzed`
 
 !!! warning "Dependency"
-    This endpoint requires the `Colmap` task to be completed. Returns HTTP 500 if missing.
+This endpoint requires the `Colmap` task to be completed. Returns HTTP 500 if missing.
 
 ---
 
 ## File Access Endpoints
 
 ### GET `/files/<path>`
+
 **Direct file access**
+
 - **Description**: Retrieve any file from the database using its path
-- **Path Parameters**: 
-  - `path`: Full path to the file within the database
+- **Path Parameters**:
+    - `path`: Full path to the file within the database
 - **Response**: File content (binary or text)
 - **Examples**:
-  - Image: `GET /files/real_plant_analyzed/images/00000_rgb.jpg`
-  - Metadata: `GET /files/real_plant_analyzed/metadata/metadata.json`
+    - Image: `GET /files/real_plant_analyzed/images/00000_rgb.jpg`
+    - Metadata: `GET /files/real_plant_analyzed/metadata/metadata.json`
 
 ### POST `/files/<scan_id>`
+
 **Upload file to dataset**
+
 - **Description**: Upload a new file to a specific scan dataset
-- **Path Parameters**: 
-  - `scan_id`: Target scan identifier
-- **Form Data**: 
-  - `file_upload`: The file to upload
+- **Path Parameters**:
+    - `scan_id`: Target scan identifier
+- **Form Data**:
+    - `file_upload`: The file to upload
 - **Response**: Upload confirmation
 - **Example**:
   ```bash
@@ -112,80 +119,94 @@ Some endpoints require authentication. Use the `/register` and `/login` endpoint
   ```
 
 ### GET `/archive/<scan_id>`
+
 **Download dataset archive**
+
 - **Description**: Download a complete dataset as a ZIP file
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier to archive
+- **Path Parameters**:
+    - `scan_id`: Scan identifier to archive
 - **Response**: ZIP file containing the entire dataset
 - **Examples**:
-  - `GET /archive/real_plant_analyzed`
-  - `GET /archive/virtual_plant_analyzed`
+    - `GET /archive/real_plant_analyzed`
+    - `GET /archive/virtual_plant_analyzed`
 
 ---
 
 ## Specialized Data Endpoints
 
 ### GET `/image/<scan_id>/<fileset_id>/<file_id>`
+
 **Access images with resizing**
+
 - **Description**: Retrieve images with optional resizing
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
-  - `fileset_id`: Fileset identifier (usually 'images')
-  - `file_id`: Image file identifier (without extension)
-- **Query Parameters**: 
-  - `size`: Image size - `orig` (original), `large`, `thumb` (thumbnail)
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
+    - `fileset_id`: Fileset identifier (usually 'images')
+    - `file_id`: Image file identifier (without extension)
+- **Query Parameters**:
+    - `size`: Image size - `orig` (original), `large`, `thumb` (thumbnail)
 - **Response**: Image file (JPEG/PNG)
 - **Examples**:
-  - Thumbnail: `GET /image/real_plant_analyzed/images/00000_rgb`
-  - Original: `GET /image/real_plant_analyzed/images/00000_rgb?size=orig`
-  - Large: `GET /image/real_plant_analyzed/images/00000_rgb?size=large`
+    - Thumbnail: `GET /image/real_plant_analyzed/images/00000_rgb`
+    - Original: `GET /image/real_plant_analyzed/images/00000_rgb?size=orig`
+    - Large: `GET /image/real_plant_analyzed/images/00000_rgb?size=large`
 
 ### GET `/pointcloud/<scan_id>/<fileset_id>/<file_id>`
+
 **Access point clouds**
+
 - **Description**: Retrieve point cloud files with optional voxel size control
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
-  - `fileset_id`: Point cloud fileset identifier
-  - `file_id`: Point cloud file identifier
-- **Query Parameters**: 
-  - `size`: `orig` (original), `preview`, or a float value for voxel size
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
+    - `fileset_id`: Point cloud fileset identifier
+    - `file_id`: Point cloud file identifier
+- **Query Parameters**:
+    - `size`: `orig` (original), `preview`, or a float value for voxel size
 - **Response**: Point cloud file (PLY format)
 - **Examples**:
-  - Preview: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud`
-  - Original: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=orig`
-  - Custom voxel: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=2.3`
+    - Preview: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud`
+    - Original: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=orig`
+    - Custom voxel: `GET /pointcloud/real_plant_analyzed/PointCloud_1_0_1_0_10_0_7ee836e5a9/PointCloud?size=2.3`
 
 ### GET `/pcGroundTruth/<scan_id>/<fileset_id>/<file_id>`
+
 **Access ground truth point clouds**
+
 - **Description**: Retrieve ground truth point cloud files
 - **Parameters**: Same as `/pointcloud` endpoint
 - **Response**: Ground truth point cloud file (PLY format)
 
 ### GET `/mesh/<scan_id>/<fileset_id>/<file_id>`
+
 **Access 3D meshes**
+
 - **Description**: Retrieve 3D mesh files
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
-  - `fileset_id`: Mesh fileset identifier
-  - `file_id`: Mesh file identifier
-- **Query Parameters**: 
-  - `size`: Currently only `orig` (original) supported
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
+    - `fileset_id`: Mesh fileset identifier
+    - `file_id`: Mesh file identifier
+- **Query Parameters**:
+    - `size`: Currently only `orig` (original) supported
 - **Response**: Mesh file (PLY format)
 - **Example**: `GET /mesh/real_plant_analyzed/TriangleMesh_9_most_connected_t_open3d_00e095c359/TriangleMesh`
 
 ### GET `/skeleton/<scan_id>`
+
 **Access curve skeleton data**
+
 - **Description**: Retrieve curve skeleton information for a scan
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 - **Response**: JSON with curve skeleton data
 - **Example**: `GET /skeleton/real_plant_analyzed`
 
 ### GET `/sequence/<scan_id>`
+
 **Access sequence information**
+
 - **Description**: Retrieve sequence-related information for a scan
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 - **Response**: JSON with sequence data
 - **Example**: `GET /sequence/real_plant_analyzed`
 
@@ -194,7 +215,9 @@ Some endpoints require authentication. Use the `/register` and `/login` endpoint
 ## Database Management
 
 ### GET `/refresh`
+
 **Refresh scan database**
+
 - **Description**: Refresh the list of scans in the database
 - **Response**: HTTP 200 on completion
 - **Example**: `GET /refresh`
@@ -206,43 +229,59 @@ Some endpoints require authentication. Use the `/register` and `/login` endpoint
 The following endpoints provide programmatic access to create and manage database content:
 
 ### POST `/api/scan`
+
 **Create new scan**
+
 - **Description**: Create a new scan dataset
 - **Request Body**: JSON with scan metadata
 - **Response**: Scan creation confirmation
 
 ### GET/POST `/api/scan/<scan_id>/metadata`
+
 **Manage scan metadata**
+
 - **Description**: Get or update scan metadata
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 
 ### GET `/api/scan/<scan_id>/filesets`
+
 **List scan filesets**
+
 - **Description**: List all filesets within a scan
-- **Path Parameters**: 
-  - `scan_id`: Scan identifier
+- **Path Parameters**:
+    - `scan_id`: Scan identifier
 
 ### POST `/api/fileset`
+
 **Create new fileset**
+
 - **Description**: Create a new fileset within a scan
 - **Request Body**: JSON with fileset information
 
 ### GET/POST `/api/fileset/<scan_id>/<fileset_id>/metadata`
+
 **Manage fileset metadata**
+
 - **Description**: Get or update fileset metadata
 
 ### GET `/api/fileset/<scan_id>/<fileset_id>/files`
+
 **List fileset files**
+
 - **Description**: List all files within a fileset
 
 ### POST `/api/file`
+
 **Create new file**
+
 - **Description**: Add a new file to a fileset
 - **Request Body**: File data and metadata
 
 ### GET/POST `/api/file/<scan_id>/<fileset_id>/<file_id>/metadata`
+
 **Manage file metadata**
+
 - **Description**: Get or update file metadata
 
 ---
@@ -250,7 +289,9 @@ The following endpoints provide programmatic access to create and manage databas
 ## Health and Status
 
 ### GET `/health`
+
 **Health check**
+
 - **Description**: Check API server health and database connectivity
 - **Response**: JSON with health status information
 - **Example**: `GET /health`
@@ -298,6 +339,7 @@ Information returned by `/scans` endpoint:
 Information returned by `/scans/<scan_id>` includes all summary fields plus:
 
 #### Camera Model
+
 ```json
 {
   "camera": {
@@ -306,24 +348,50 @@ Information returned by `/scans/<scan_id>` includes all summary fields plus:
       "model": "OPENCV",
       "width": 1440,
       "height": 1080,
-      "params": [1166.95, 1166.95, 720, 540, -0.0014, -0.0014, 0, 0]
+      "params": [
+        1166.95,
+        1166.95,
+        720,
+        540,
+        -0.0014,
+        -0.0014,
+        0,
+        0
+      ]
     }
   }
 }
 ```
 
 #### Camera Poses
+
 ```json
 {
   "camera": {
     "poses": [
       {
         "id": 1,
-        "tvec": [369.43, 120.36, -62.07],
+        "tvec": [
+          369.43,
+          120.36,
+          -62.07
+        ],
         "rotmat": [
-          [0.0648, -0.9972, 0.0382],
-          [-0.3390, -0.0580, -0.9390],
-          [0.9385, 0.0479, -0.3418]
+          [
+            0.0648,
+            -0.9972,
+            0.0382
+          ],
+          [
+            -0.3390,
+            -0.0580,
+            -0.9390
+          ],
+          [
+            0.9385,
+            0.0479,
+            -0.3418
+          ]
         ],
         "photoUri": "/files/scan_id/images/00000_rgb.jpg",
         "thumbnailUri": "/files/scan_id/images/00000_rgb?size=thumb",
@@ -335,12 +403,22 @@ Information returned by `/scans/<scan_id>` includes all summary fields plus:
 ```
 
 #### Reconstruction Workspace
+
 ```json
 {
   "workspace": {
-    "x": [340, 440],
-    "y": [330, 410], 
-    "z": [-180, 105]
+    "x": [
+      340,
+      440
+    ],
+    "y": [
+      330,
+      410
+    ],
+    "z": [
+      -180,
+      105
+    ]
   }
 }
 ```

--- a/docs/rest_api/rest_api_usage.md
+++ b/docs/rest_api/rest_api_usage.md
@@ -1,0 +1,139 @@
+# How to Run the REST API
+
+Below is a quick‑start guide that covers the most common ways to launch the **PlantDB REST API**.  
+All the commands work on any platform where Python 3.10+ is available and the `plantdb.server` package has been installed (_e.g._ via `pip install plantdb.server` or from source).
+
+## Core concepts
+
+| Concept                    | What it is                                                                     | Where to configure it                                            |
+|----------------------------|--------------------------------------------------------------------------------|------------------------------------------------------------------|
+| **Database location**      | Path to the local FSDB that stores scans, images, point clouds, etc.           | `ROMI_DB` environment variable **or** `--db_location` CLI option |
+| **API URL prefix**         | Optional prefix (_e.g._ `/api/v1`) that will be added in front of every endpoint | `PLANTDB_API_PREFIX` env‑var (used by the WSGI entry‑point)      |
+| **SSL**                    | Enforce HTTPS‑only cookies (important when the server is exposed publicly)     | `PLANTDB_API_SSL=true`                                           |
+| **Authentication secrets** | Randomly generated if omitted; control session and JWT handling                | `FLASK_SECRET_KEY` and `JWT_SECRET_KEY`                          |
+| **Session limits**         | Maximum concurrent sessions, JWT lifetime, refresh token TTL                   | `MAX_SESSION`, `SESSION_TIMEOUT`, `REFRESH_TIMEOUT`              |
+| **Proxy support**          | Required when the service sits behind a reverse proxy (_e.g._ Nginx, uWSGI)      | `--proxy` flag (CLI)                                             |
+
+All of the above are documented in the module doc‑strings of **`fsdb_rest_api.py`** (the CLI) and **`wsgi.py`** (the WSGI entry point).
+
+## Test mode – Play with a temporary toy dataset
+
+If you just want to explore the API without touching any real data, start the server in **test mode**.
+A temporary database (populated with a small sample dataset) is created automatically and removed when the process exits.
+
+```shell
+python fsdb_rest_api.py --test --debug
+```
+
+| Option                  | Effect                                                                 |
+|-------------------------|------------------------------------------------------------------------|
+| `--test`                | Builds a temporary FSDB (includes sample scans, images, point clouds). |
+| `--debug`               | Runs Flask’s built‑in debugger (auto‑reload, detailed error pages).    |
+| `--empty` *(optional)*  | Skip loading the sample dataset – you get an **empty** database.       |
+| `--models` *(optional)* | Add pre‑trained CNN models to the temporary DB (useful for ML demos).  |
+
+The server will listen on `0.0.0.0:5000` by default, which you can reach at **`http://localhost:5000/`**.
+
+## Development – Run against a real local FSDB
+
+When you have an existing PlantDB directory that you want to expose, start the server with explicit host/port settings:
+
+```shell
+python fsdb_rest_api.py \
+    --db_location /path/to/your/database \
+    --host 127.0.0.1 \
+    --port 8080 \
+    --debug          # optional: turn on Flask debug mode
+```
+
+**Key CLI flags**
+
+| Flag            | Description                                                                                      |
+|-----------------|--------------------------------------------------------------------------------------------------|
+| `--db_location` | Path to the FSDB you wish to serve. If omitted, the environment variable `ROMI_DB` is consulted. |
+| `--host`        | Network interface to bind (default `0.0.0.0`).                                                   |
+| `--port`        | TCP port (default `5000`).                                                                       |
+| `--proxy`       | Tell the app it is behind a reverse proxy; the server will respect the `X‑Forwarded-*` headers.  |
+| `--log-level`   | Choose among `debug`, `info`, `warning`, `error`, `critical` (defaults to `INFO`).               |
+
+**Example**: Behind a reverse proxy (e.g. Nginx)
+
+```shell
+python fsdb_rest_api.py \
+    --db_location /data/plantdb \
+    --host 127.0.0.1 \
+    --port 5000 \
+    --proxy
+```
+
+The proxy will forward requests to `127.0.0.1:5000`; the app will automatically strip the proxy prefix (if set via
+`PLANTDB_API_PREFIX`) and generate correct URLs in responses.
+
+
+## Production – Deploy with a WSGI server (uWSGI, Gunicorn)
+
+For a robust, multi‑process deployment you typically use a dedicated WSGI server.
+The **`wsgi.py`** module provides the ready‑to‑import `application` object:
+
+```shell
+uwsgi --http :5000 \
+      --module plantdb.server.cli.wsgi:application \
+      --callable application \
+      --master
+```
+
+| Parameter                                      | Meaning                                                      |
+|------------------------------------------------|--------------------------------------------------------------|
+| `--http :5000`                                 | Expose the service on port 5000 (change as needed).          |
+| `--module plantdb.server.cli.wsgi:application` | Import the WSGI entry point.                                 |
+| `--callable application`                       | The Flask app instance created by `rest_api()`.              |
+| `--master`                                     | Run uWSGI in master mode (recommended for graceful reloads). |
+
+**Environment variables** (set before starting uWSGI) let you customise the deployment without touching code:
+
+```shell
+export ROMI_DB=/srv/plantdb
+export PLANTDB_API_PREFIX=/api/v1
+export PLANTDB_API_SSL=true          # enforce HTTPS‑only cookies
+export FLASK_SECRET_KEY=myflasksecret
+export JWT_SECRET_KEY=myjwtsecret
+export SESSION_TIMEOUT=1800         # 30 min
+export REFRESH_TIMEOUT=86400        # 1 day
+export MAX_SESSION=20               # up to 20 concurrent users
+```
+
+The server will then be reachable at **`https://<host>:5000/api/v1/`** (or without the prefix if you leave
+`PLANTDB_API_PREFIX` empty).
+
+## Quick reference of the most useful endpoints
+
+| Endpoint                                       | Method           | Description                                      |
+|------------------------------------------------|------------------|--------------------------------------------------|
+| `/`                                            | `GET`            | Health check & basic landing page.               |
+| `/health`                                      | `GET`            | Detailed service health (database connectivity). |
+| `/scans`                                       | `GET`            | List all scans (optionally filter by owner).     |
+| `/scans_info`                                  | `GET`            | Tabular view with additional metadata.           |
+| `/scan/<scan_id>`                              | `GET/PUT/DELETE` | CRUD operations on a single scan.                |
+| `/scan/<scan_id>/filesets`                     | `GET/POST`       | List or create filesets belonging to a scan.     |
+| `/file/<scan_id>/<fileset_id>/<file_id>`       | `GET/PUT/DELETE` | Access or modify a concrete file.                |
+| `/image/<scan_id>/<fileset_id>/<file_id>`      | `GET`            | Retrieve an image asset.                         |
+| `/pointcloud/<scan_id>/<fileset_id>/<file_id>` | `GET`            | Retrieve a point‑cloud asset.                    |
+| `/mesh/<scan_id>/<fileset_id>/<file_id>`       | `GET`            | Retrieve a mesh asset.                           |
+| `/register`                                    | `POST`           | Create a new user account.                       |
+| `/login`                                       | `POST`           | Obtain a JWT access token.                       |
+| `/logout`                                      | `POST`           | Invalidate the current JWT.                      |
+| `/token-refresh`                               | `POST`           | Refresh an access token using a refresh token.   |
+| `/create-api-token`                            | `POST`           | Generate a long‑lived API token (for scripts).   |
+
+All routes respect the optional **URL prefix** (
+`PLANTDB_API_PREFIX`) and enforce JWT authentication when the corresponding resource requires it.
+
+## Common troubleshooting tips
+
+| Symptom                                              | Likely cause                                                                                  | Fix                                                                                                                                             |
+|------------------------------------------------------|-----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| **“No secret key was provided”** warnings on startup | Environment variables `FLASK_SECRET_KEY` / `JWT_SECRET_KEY` not set.                          | Either export those variables or let the server generate a random 64‑bit secret (the warning can be ignored for local testing).                 |
+| **“Connecting to local plant database …” fails**     | Wrong `ROMI_DB` path or missing read permissions.                                             | Verify the path exists and is readable; set `ROMI_DB` correctly or use `--db_location`.                                                         |
+| **All endpoints return 404**                         | The server is running behind a proxy but `--proxy` flag (or `PLANTDB_API_PREFIX`) is not set. | Restart with `--proxy` and/or configure `PLANTDB_API_PREFIX`.                                                                                   |
+| **CORS errors from a web front‑end**                 | Cross‑origin requests blocked.                                                                | The Flask app enables CORS globally; ensure the browser is not caching old headers, or restrict origins via Flask‑CORS configuration if needed. |
+| **SSL not enforced**                                 | `PLANTDB_API_SSL` is not true, or cookies are still sent over HTTP.                           | Set `PLANTDB_API_SSL=true` and serve the app via HTTPS (e.g., terminate TLS at the reverse proxy).                                              |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,10 @@ repo_url: https://github.com/romi/plantdb
 nav:
   - 'Home': index.md
   - 'PlantDB Sync UI': plantdb_sync.md
-  - 'REST API': rest_api.md
+  - 'REST API':
+    - rest_api/index.md
+    - rest_api/rest_api_usage.md
+    - rest_api/rest_api_endpoints.md
   - 'Reference API': reference/
   - 'Developers' :
     - 'Release Guide': developers/releases.md

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -1,4 +1,4 @@
-# [![ROMI_logo](../../docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / PlantDB.client
+# [![ROMI_logo](https://github.com/romi/plantdb/blob/ab29155f0bc0ad755c3455c4db3eb56c4bbd1b0e/docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / PlantDB.client
 
 [![Licence](https://img.shields.io/github/license/romi/plantdb?color=lightgray)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 [![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fromi%2Fplantdb%2Frefs%2Fheads%2Fdev%2Fsrc%2Fcommons%2Fpyproject.toml&logo=python&logoColor=white)]()

--- a/src/client/plantdb/client/api_endpoints.py
+++ b/src/client/plantdb/client/api_endpoints.py
@@ -417,8 +417,6 @@ def fileset(scan_id, fileset_id, **kwargs) -> str:
         The name of the scan to access.
     fileset_id : str
         The name of the fileset to access.
-    file_id : str
-        The name of the file to access.
 
     Other Parameters
     ----------------

--- a/src/client/pyproject.toml
+++ b/src/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plantdb.client"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
     "plantdb.commons",
     "requests",

--- a/src/commons/README.md
+++ b/src/commons/README.md
@@ -1,4 +1,4 @@
-# [![ROMI_logo](../../docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / PlantDB.commons
+# [![ROMI_logo](https://github.com/romi/plantdb/blob/ab29155f0bc0ad755c3455c4db3eb56c4bbd1b0e/docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / PlantDB.commons
 
 [![Licence](https://img.shields.io/github/license/romi/plantdb?color=lightgray)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 [![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fromi%2Fplantdb%2Frefs%2Fheads%2Fdev%2Fsrc%2Fcommons%2Fpyproject.toml&logo=python&logoColor=white)]()

--- a/src/commons/plantdb/commons/auth/__init__.py
+++ b/src/commons/plantdb/commons/auth/__init__.py
@@ -35,7 +35,7 @@ Usage Examples
 >>>
 >>> # RBAC operations
 >>> rbac_mgr = rbac.RBACManager()
->>> user = rbac_mgr.users.create_user("alice", roles={rbac.Role.CONTRIBUTOR})
+>>> user = rbac_mgr.create_user("alice", roles={rbac.Role.CONTRIBUTOR})
 >>> rbac_mgr.create_group(user, "researchers")
 >>> rbac_mgr.add_user_to_group(user, "researchers", "alice")
 >>> scan_meta = {"owner": "bob", "sharing": ["researchers"]}

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -642,7 +642,7 @@ class UserManager(object):
         password : str
             The current password of the user to verify their identity.
         new_password : str
-            The new password to set for the user. If ``None``, no change will occur.
+            The new password to set for the user. If ``None`` or empty, no change will occur.
         """
         # Verify if the login exists
         try:
@@ -657,7 +657,7 @@ class UserManager(object):
         user = self.get_user(username)
         timestamp = datetime.now()  # Get the current timestamp for tracking user creation time.
         if new_password:
-            user.password = self._hash_password(new_password)
+            user.password_hash = self._hash_password(new_password)
             user.password_last_change = timestamp
 
         self._save_users()
@@ -701,7 +701,7 @@ class GroupManager:
             self.logger.warning(f"Empty groups database file found under '{self.groups_file}'")
             self.groups = {}
         else:
-            # Load the groups list from the database
+            # Load the group list from the database
             with open(self.groups_file, 'r') as f:
                 data = json.load(f)
             # Convert to a group-name indexed dict of Group objects

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -673,18 +673,18 @@ class GroupManager:
 
     Attributes
     ----------
-    groups_file : Union[str, Path]
+    groups_file : str | Path
         Path to the JSON file where groups are stored.
     groups : Dict[str, plantdb.commons.auth.models.Group]
         Dictionary mapping group names to Group objects.
     """
 
-    def __init__(self, groups_file: Union[str, Path] = "groups.json"):
+    def __init__(self, groups_file: str | Path = "groups.json"):
         """Initialize the GroupManager.
 
         Parameters
         ----------
-        groups_file : Union[str, Path]
+        groups_file : str | Path
             Path to the JSON file for storing groups. Defaults to "groups.json".
         """
         self.groups_file = Path(groups_file)

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -116,7 +116,7 @@ class UserManager(object):
         Parameters
         ----------
         users_file : str or pathlib.Path, optional
-            Path to the JSON file where user data is stored. Defaults to ``users.json``.
+            The path to the JSON file where user data is stored. Defaults to ``"users.json"``.
         max_login_attempts : int, optional
             Maximum number of failed login attempts before account lockout. Defaults to ``3``.
         lockout_duration : int or timedelta, optional
@@ -139,22 +139,22 @@ class UserManager(object):
     def _load_users(self) -> None:
         """Loads the user database from a JSON file and populates the internal dictionary.
 
-        This method checks if the users database file exists. If it does not exist, it initializes an empty dictionary,
+        This method checks if the user database file exists. If it does not exist, it initializes an empty dictionary,
         creates the file, and logs a warning message. If the file does exist, it loads the user data from the file,
         converts each user to a `User` object, and populates the internal dictionary with these objects.
 
         Notes
         -----
-        The method assumes that the users database file is in JSON format and contains valid user data.
+        The method assumes that the user database file is in JSON format and contains valid user data.
         """
         if not self.users_file.exists():
-            self.logger.warning(f"No users database file found under '{self.users_file}'")
+            self.logger.warning(f"No user database file found under '{self.users_file}'")
             self.users = {}
         elif self.users_file.stat().st_size == 0:
-            self.logger.warning(f"Empty users database file found under '{self.users_file}'")
+            self.logger.warning(f"Empty user database file found under '{self.users_file}'")
             self.users = {}
         else:
-            # Load the users list from the database
+            # Load the list of users from the database
             with open(self.users_file, "r") as f:
                 users_list = json.load(f)
             # Convert to a username indexed dict of User objects
@@ -665,7 +665,7 @@ class UserManager(object):
         return
 
 
-class GroupManager:
+class GroupManager(object):
     """Manages groups for the RBAC system.
 
     This class handles the creation, modification, and persistence of user groups.
@@ -674,18 +674,19 @@ class GroupManager:
     Attributes
     ----------
     groups_file : str | Path
-        Path to the JSON file where groups are stored.
+        The path to the JSON file where groups are stored.
     groups : Dict[str, plantdb.commons.auth.models.Group]
         Dictionary mapping group names to Group objects.
     """
 
     def __init__(self, groups_file: str | Path = "groups.json"):
-        """Initialize the GroupManager.
+        """
+        Initialize the GroupManager.
 
         Parameters
         ----------
-        groups_file : str | Path
-            Path to the JSON file for storing groups. Defaults to "groups.json".
+        groups_file : str | Path, optional
+            The path to the JSON file for storing groups. Defaults to ``"groups.json"``.
         """
         self.groups_file = Path(groups_file)
         self.groups: Dict[str, Group] = {}

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -58,6 +58,7 @@ from plantdb.commons.auth.models import Role
 from plantdb.commons.auth.models import TokenUser
 from plantdb.commons.auth.models import User
 from plantdb.commons.log import get_logger
+from plantdb.commons.utils import yes_no_choice
 
 ph = PasswordHasher()
 
@@ -183,11 +184,16 @@ class UserManager(object):
             # Convert to a username indexed dict of User objects
             try:
                 self._parse_user_list(users_list)
-            except Exception as e:
+            except Exception:
                 self.logger.critical(f"Error parsing user list")
-                if 'role' not in users_list[0]:
+                if isinstance(users_list, dict) and 'role' not in list(users_list.values())[0]:
                     self.logger.warning("You are using an outdated user database file")
-                    self.logger.info("Fix it with `scripts/fix_local_fsdb.py`")
+                    if yes_no_choice("Do you want to replace it?", default=True):
+                        pass
+                    else:
+                        raise
+                else:
+                    raise
         return
 
     def _save_users(self) -> None:

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -44,6 +44,7 @@ import os
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -136,6 +137,30 @@ class UserManager(object):
         self.lockout_duration = timedelta(seconds=lockout_duration) if isinstance(lockout_duration,
                                                                                   int) else lockout_duration
 
+    def _load_user_file(self) -> list[dict[str, Any]]:
+        """Load the list of users from the database."""
+        with open(self.users_file, "r") as f:
+            users_list = json.load(f)
+        return users_list
+
+    def _parse_user_list(self, users_list: list[dict[str, Any]]) -> None:
+        """Convert to a username indexed dict of User objects.
+
+        Parameters
+        ----------
+        users_list : list of dict
+            List of user data dictionaries loaded from the JSON persistence file.
+            Each dictionary must contain the keys required by ``User.from_dict``.
+
+        See Also
+        --------
+        plantdb.commons.auth.models.User.from_dict : Class method that creates a `User` from a dict.
+        """
+        for user in users_list:
+            user = User.from_dict(user)
+            self.users[user.username] = user
+        self.logger.debug(f"Loaded {len(self.users)} users from '{self.users_file}'.")
+
     def _load_users(self) -> None:
         """Loads the user database from a JSON file and populates the internal dictionary.
 
@@ -147,22 +172,22 @@ class UserManager(object):
         -----
         The method assumes that the user database file is in JSON format and contains valid user data.
         """
+        self.users = {}
         if not self.users_file.exists():
             self.logger.warning(f"No user database file found under '{self.users_file}'")
-            self.users = {}
         elif self.users_file.stat().st_size == 0:
             self.logger.warning(f"Empty user database file found under '{self.users_file}'")
-            self.users = {}
         else:
             # Load the list of users from the database
-            with open(self.users_file, "r") as f:
-                users_list = json.load(f)
+            users_list = self._load_user_file()
             # Convert to a username indexed dict of User objects
-            self.users = {}
-            for user in users_list:
-                user = User.from_dict(user)
-                self.users[user.username] = user
-            self.logger.debug(f"Loaded {len(self.users)} users from '{self.users_file}'.")
+            try:
+                self._parse_user_list(users_list)
+            except Exception as e:
+                self.logger.critical(f"Error parsing user list")
+                if 'role' not in users_list[0]:
+                    self.logger.warning("You are using an outdated user database file")
+                    self.logger.info("Fix it with `scripts/fix_local_fsdb.py`")
         return
 
     def _save_users(self) -> None:

--- a/src/commons/plantdb/commons/auth/manager.py
+++ b/src/commons/plantdb/commons/auth/manager.py
@@ -189,7 +189,8 @@ class UserManager(object):
                 if isinstance(users_list, dict) and 'role' not in list(users_list.values())[0]:
                     self.logger.warning("You are using an outdated user database file")
                     if yes_no_choice("Do you want to replace it?", default=True):
-                        pass
+                        # No error raised, the method returns with an empty dictionary for the `users` attribute
+                        self.users = {}  # force an empty users database to trigger the creation of a new user database
                     else:
                         raise
                 else:

--- a/src/commons/plantdb/commons/auth/rbac.py
+++ b/src/commons/plantdb/commons/auth/rbac.py
@@ -36,6 +36,7 @@ True
 """
 
 from functools import wraps
+from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -111,18 +112,33 @@ class RBACManager:
     --------
     >>> from plantdb.commons.auth.rbac import RBACManager
     >>> rbac = RBACManager()
-    >>> rbac.
+    >>> # Get the 'guest' user and have a look at its permissions
+    >>> guest = rbac.get_guest_user()
+v    >>> rbac.get_user_permissions(guest)
+    {<Permission.READ: 'read'>}
+    >>> rbac.can_create_group(guest)
+    False
+    >>> # Get the 'admin' user and create a new user
+    >>> admin = rbac.users.get_user('admin')
+    >>> rbac.can_create_user(admin)
+    True
+    >>> rbac.create_user(admin, 'butcher', 'Billy Butcher', 'terror')
+    >>> # The user database JSON file now has this user registered
+    >>> import json
+    >>> with open(rbac.users.users_file, 'r') as f: user_db = json.load(f)
+    >>> 'butcher' in [entry['username'] for entry in user_db]
     """
 
-    def __init__(self, users_file: str = 'users.json', groups_file: str = "groups.json", max_login_attempts=3,
-                 lockout_duration=900):
-        """Initialize the RBACManager.
+    def __init__(self, users_file: str | Path = 'users.json', groups_file: str | Path = "groups.json",
+                 max_login_attempts=3, lockout_duration=900):
+        """
+        Initialize the RBACManager.
 
         Parameters
         ----------
-        users_file : str, optional
+        users_file : str | Path, optional
             Path to the JSON file acting as users' database. Default is 'users.json'.
-        groups_file : str, optional
+        groups_file : str | Path, optional
             Path to the JSON file acting as groups' database. Defaults to "groups.json".
         max_login_attempts : int, optional
             Maximum number of failed login attempts before account lockout. Defaults to ``3``.

--- a/src/commons/plantdb/commons/auth/rbac.py
+++ b/src/commons/plantdb/commons/auth/rbac.py
@@ -24,7 +24,7 @@ Usage Examples
 >>> from plantdb.commons.auth.rbac import RBACManager, Permission, User
 >>> rbac = RBACManager()
 >>> # Create a new user and assign a role
->>> user = rbac.users.create_user('alice', roles={'CONTRIBUTOR'})
+>>> user = rbac.create_user('alice', roles={'CONTRIBUTOR'})
 >>> # Create a group and add the user
 >>> rbac.create_group(user, 'researchers')
 >>> rbac.add_user_to_group(user, 'researchers', 'alice')
@@ -91,7 +91,7 @@ def requires_permission(required_permissions: Union[Permission, List[Permission]
     return decorator
 
 
-class RBACManager :
+class RBACManager:
     """Manage Role-Based Access Control (RBAC) for users and permissions.
 
     This class provides methods to determine which permissions a user has,
@@ -100,22 +100,18 @@ class RBACManager :
 
     Attributes
     ----------
-    GUEST_USERNAME : str
-        The username for the default guest user account.
+    logger : logging.logger
+        The logger to use with this class.
+    users : plantdb.commons.auth.manager.UserManager
+        Manager for handling user operations.
     groups : plantdb.commons.auth.manager.GroupManager
         Manager for handling group operations.
 
     Examples
     --------
     >>> from plantdb.commons.auth.rbac import RBACManager
-    >>> from plantdb.commons.test_database import test_database
-    >>> db = test_database('all')
-    >>> db.connect()
-    >>> scan = db.get_scan('real_plant_analyzed')
     >>> rbac = RBACManager()
-    >>> guest_user = rbac.create_guest_user('guest')
-    >>> can_read = rbac.can_access_scan(guest_user, scan.metadata, Permission.READ)
-
+    >>> rbac.
     """
 
     def __init__(self, users_file: str = 'users.json', groups_file: str = "groups.json", max_login_attempts=3,
@@ -125,9 +121,9 @@ class RBACManager :
         Parameters
         ----------
         users_file : str, optional
-            Path to the JSON file for storing users database. Default is 'users.json'.
+            Path to the JSON file acting as users' database. Default is 'users.json'.
         groups_file : str, optional
-            Path to the JSON file for storing groups database. Defaults to "groups.json".
+            Path to the JSON file acting as groups' database. Defaults to "groups.json".
         max_login_attempts : int, optional
             Maximum number of failed login attempts before account lockout. Defaults to ``3``.
         lockout_duration : int or timedelta, optional
@@ -269,6 +265,45 @@ class RBACManager :
         """
         return self.has_permission(user, Permission.MANAGE_USERS)
 
+    def create_user(self, requesting_user: User, username: str, fullname: str, password: str,
+                    roles: Role | set[Role] | None = None) -> User | None:
+        """Create a new user account.
+
+        This method verifies that the requesting user has the ``MANAGE_USERS`` permission,
+        logs the creation attempt, and forwards the actual creation to the underlying
+        ``UserManager``.  It returns the newly created ``User`` object on success or ``None``
+        if the operation is not permitted.
+
+        Parameters
+        ----------
+        requesting_user : plantdb.commons.auth.models.User
+            The user performing the creation request.
+        username : str
+            Desired username for the new account.
+        fullname : str
+            The full name of the user to create.
+        password : str
+            Password for the new account.
+        roles : Role | set[Role] | None
+            Set of roles to assign to the new user.
+            If ``None`` (default), use the `Role.READER` role.
+
+        Returns
+        -------
+        User | None
+            The created ``User`` instance, or ``None`` if creation was denied.
+        """
+        if not self.can_create_user(requesting_user):
+            self.logger.error(
+                f"User '{requesting_user.username}' attempted to create user '{username}' without sufficient permission."
+            )
+            return None
+
+        self.logger.info(
+            f"User '{requesting_user.username}' is creating new user '{username}' with {roles=}."
+        )
+        return self.users.create(username, fullname, password, roles=roles)
+
     def can_manage_groups(self, user: User) -> bool:
         """Check if a user can manage groups (create/delete groups).
 
@@ -401,7 +436,8 @@ class RBACManager :
             ``False`` if the permission was denied or the operation failed.
         """
         if not self.can_add_to_group(user, group_name):
-            self.logger.error(f"Insufficient permission to add user '{username_to_add}' to group '{group_name}' by user '{user.username}!")
+            self.logger.error(
+                f"Insufficient permission to add user '{username_to_add}' to group '{group_name}' by user '{user.username}!")
             return False
         self.logger.info(f"Adding user '{username_to_add}' from group '{group_name}' by user '{user.username}'!")
         return self.groups.add_user_to_group(group_name, username_to_add)
@@ -425,9 +461,11 @@ class RBACManager :
             ``False`` if the permission was denied or the operation failed.
         """
         if not self.can_add_to_group(user, group_name):  # Same permission as adding
-            self.logger.error(f"Insufficient permission to remove user '{username_to_remove}' from group '{group_name}' by user '{user.username}!")
+            self.logger.error(
+                f"Insufficient permission to remove user '{username_to_remove}' from group '{group_name}' by user '{user.username}!")
             return False
-        self.logger.warning(f"Removing user '{username_to_remove}' from group '{group_name}' by user '{user.username}'!")
+        self.logger.warning(
+            f"Removing user '{username_to_remove}' from group '{group_name}' by user '{user.username}'!")
         return self.groups.remove_user_from_group(group_name, username_to_remove)
 
     def delete_group(self, user: User, group_name: str) -> bool:

--- a/src/commons/plantdb/commons/auth/rbac.py
+++ b/src/commons/plantdb/commons/auth/rbac.py
@@ -60,7 +60,7 @@ def requires_permission(required_permissions: Union[Permission, List[Permission]
 
     Parameters
     ----------
-    required_permission:  Union[Permission, List[Permission]]
+    required_permissions: Union[Permission, List[Permission]]
         A single permission string or list of permission that the user must have to access the decorated method.
     """
 

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -240,6 +240,20 @@ class SessionManager:
         self.cleanup_expired_sessions()
         return len(self.sessions)
 
+    def has_logged_user(self) -> bool:
+        """Check if there is at least one active (logged‑in) user.
+
+        This method first cleans up any expired sessions and then determines
+        whether the internal ``sessions`` dictionary contains any entries.
+
+        Returns
+        -------
+        bool
+            ``True`` if at least one user has an active session, ``False`` otherwise.
+        """
+        self.cleanup_expired_sessions()
+        return len(self.sessions) > 0
+
     def _create_token(self, **kwargs) -> str:
         """Generate a secure random token.
 

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -27,6 +27,7 @@ Usage Examples
 {'username': 'alice', 'issued_at': 1769011058, 'expires_at': 1769012858, 'jti': 'HVaAR4XHmIJgCKbZMDqmwg', 'issuer': 'plantdb-api', 'audience': 'plantdb-client'}
 >>> new_token = manager.refresh_session(token)
 """
+import os
 import secrets
 import threading
 import time
@@ -550,6 +551,8 @@ class NoAuthSessionManager(SessionManager):
     """
 
     def __init__(self, session_timeout: int = 3600) -> None:
+        if os.environ.get('ROMI_DB_NOAUTH', 1) == 0:
+            raise RuntimeError('Unable to use NoAuthSessionManager, forbidden by environment variable!')
         # Force a single‑session policy; the real admin manager does the same.
         super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
         self._admin_username = "admin"

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -747,12 +747,12 @@ class JWTSessionManager(SessionManager):
             The maximum number of concurrent sessions to allow.
             Defaults to ``10``.
         secret_key : str | bytes | None
-           Secret used for HS512 signing of JWTs.
-           - If a ``bytes`` object is supplied, it must be ≥ 64 bytes.
-           - If a ``str`` (pass‑phrase) is supplied, it will be stretched with Argon2 to produce a 64‑byte key.
-           - If ``None`` (default) a fresh random 64‑byte key is generated.
-             This will break the API tokens persistence across restarts as, after a restart, the new instance
-             gets a different secret key, so all previously persisted API tokens in the file become unverifiable.
+            Secret used for HS512 signing of JWTs.
+            - If a ``bytes`` object is supplied, it must be ≥ 64 bytes.
+            - If a ``str`` (pass‑phrase) is supplied, it will be stretched with Argon2 to produce a 64‑byte key.
+            - If ``None`` (default) a fresh random 64‑byte key is generated.
+              This will break the API tokens persistence across restarts as, after a restart, the new instance
+              gets a different secret key, so all previously persisted API tokens in the file become unverifiable.
         leeway : int, optional
             Allowed leeway, in seconds, after tokens expiration date, to accommodate for clock-skew.
             Set it to `0` so that the token is considered expired immediately after its exp claim passes.

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -551,11 +551,12 @@ class NoAuthSessionManager(SessionManager):
     """
 
     def __init__(self, session_timeout: int = 3600) -> None:
+        # Abort if environment explicitly disables NoAuth mode.
         if os.environ.get('ROMI_DB_NOAUTH', 1) == 0:
             raise RuntimeError('Unable to use NoAuthSessionManager, forbidden by environment variable!')
-        # Force a single‑session policy; the real admin manager does the same.
+        # Initialize base SessionManager with single‑session limit.
         super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
-        self._admin_username = "admin"
+        self._admin_username = "admin"  # Fixed admin username.
         # Create the admin session eagerly.
         self._admin_token = super().create_session(self._admin_username)
 
@@ -570,30 +571,26 @@ class NoAuthSessionManager(SessionManager):
     # Overridden SessionManager API
     # ------------------------------------------------------------------
     def create_session(self, username: str | None = None) -> str | None:
-        """
-        Ignore the supplied *username* – always return the pre‑created admin token.
-        This mirrors the behavior of ``AdminSessionManager`` but without any conditional logic.
-        """
+        """Ignore the supplied `username` and always return the pre‑created admin token."""
         return self._admin_token
 
     def validate_session(self, session_id: str) -> dict | None:
         """
-        Validate the stored admin token.  If it has expired, recreate it
-        and return the fresh session information.
+        Validate the stored admin token.
+
+        If it has expired, recreate it and return the fresh session information.
         """
         # First try the existing token; ``super().validate_session`` also updates ``last_accessed``.
         session = super().validate_session(self._admin_token)
         if session is None:
-            # Token expired → make a new one.
+            # Token is expired, so we generate a new one.
             self._admin_token = super().create_session(self._admin_username)
             session = super().validate_session(self._admin_token)
         return session
 
     def session_username(self, session_id: str) -> str | None:
         """Always return ``admin`` for any session identifier."""
-        # We bypass the parent implementation because it would look up the
-        # token in ``self.sessions`` – we know the admin token is always
-        # present (or recreated above).
+        # We bypass the parent implementation because it would look up the token in ``self.sessions``
         return self._admin_username
 
 

--- a/src/commons/plantdb/commons/auth/session.py
+++ b/src/commons/plantdb/commons/auth/session.py
@@ -520,6 +520,80 @@ class SingleSessionManager(SessionManager):
         super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
 
 
+class NoAuthSessionManager(SessionManager):
+    """
+    A session manager for testing where every request is considered
+    authenticated as the built‑in ``admin`` user.
+
+    - The admin token is created once at construction and reused.
+    - ``validate_session`` always succeeds (refreshes the token only when it has expired).
+    - Suitable for use in `plantdb.commons.fsdb.core.FSDB` tests and
+      docstring examples where security is irrelevant.
+
+    Examples
+    --------
+    >>> from plantdb.commons.auth.session import NoAuthSessionManager
+    >>> noauth_sm = NoAuthSessionManager()
+    >>> token = noauth_sm.admin_token()
+    >>> noauth_sm.validate_session(token)['username']
+    'admin'
+    >>> # Any request that expects a session manager can now receive `noauth_sm` without worrying about authentication.
+    >>> from plantdb.commons.test_database import setup_test_database
+    >>> from plantdb.commons.fsdb.core import FSDB
+    >>> db_path = setup_test_database('real_plant')
+    >>> db = FSDB(db_path, session_manager=NoAuthSessionManager())
+    >>> db.connect()
+    >>> scan = db.get_scan('real_plant')  # no need to log in to access the dataset
+    >>> scan.set_metadata('test', "No authentication required to write stuff!")
+    >>> print(scan.get_metadata('test'))
+    No authentication required to write stuff!
+    """
+
+    def __init__(self, session_timeout: int = 3600) -> None:
+        # Force a single‑session policy; the real admin manager does the same.
+        super().__init__(session_timeout=session_timeout, max_concurrent_sessions=1)
+        self._admin_username = "admin"
+        # Create the admin session eagerly.
+        self._admin_token = super().create_session(self._admin_username)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def admin_token(self) -> str | None:
+        """Return the (static) admin token."""
+        return self._admin_token
+
+    # ------------------------------------------------------------------
+    # Overridden SessionManager API
+    # ------------------------------------------------------------------
+    def create_session(self, username: str | None = None) -> str | None:
+        """
+        Ignore the supplied *username* – always return the pre‑created admin token.
+        This mirrors the behavior of ``AdminSessionManager`` but without any conditional logic.
+        """
+        return self._admin_token
+
+    def validate_session(self, session_id: str) -> dict | None:
+        """
+        Validate the stored admin token.  If it has expired, recreate it
+        and return the fresh session information.
+        """
+        # First try the existing token; ``super().validate_session`` also updates ``last_accessed``.
+        session = super().validate_session(self._admin_token)
+        if session is None:
+            # Token expired → make a new one.
+            self._admin_token = super().create_session(self._admin_username)
+            session = super().validate_session(self._admin_token)
+        return session
+
+    def session_username(self, session_id: str) -> str | None:
+        """Always return ``admin`` for any session identifier."""
+        # We bypass the parent implementation because it would look up the
+        # token in ``self.sessions`` – we know the admin token is always
+        # present (or recreated above).
+        return self._admin_username
+
+
 def _derive_key_argon2(password: str) -> bytes:
     """Derive a 64‑byte (512‑bit) secret using Argon2.
 

--- a/src/commons/plantdb/commons/db.py
+++ b/src/commons/plantdb/commons/db.py
@@ -210,7 +210,7 @@ class Scan(object):
         raise NotImplementedError
 
     def get_metadata(self, key=None, default=None):
-        """Get metadata associated to scan.
+        """Get metadata associated with scan.
 
         Parameters
         ----------
@@ -227,7 +227,7 @@ class Scan(object):
         raise NotImplementedError
 
     def set_metadata(self, data, value=None):
-        """Get metadata associated to scan.
+        """Get metadata associated with scan.
 
         If value is ``None``, scan metadata is set to data.
         If value is not ``None`` data is a key and is set to value.
@@ -362,7 +362,7 @@ class Fileset(object):
         raise NotImplementedError
 
     def get_metadata(self, key=None, default=None):
-        """Get metadata associated to scan.
+        """Get metadata associated with scan.
 
         Parameters
         ----------
@@ -379,7 +379,7 @@ class Fileset(object):
         raise NotImplementedError
 
     def set_metadata(self, data, value=None):
-        """Get metadata associated to scan.
+        """Get metadata associated with scan.
 
         If value is ``None``, scan metadata is set to data.
         If value is not ``None`` data is a key and is set to value.
@@ -506,7 +506,7 @@ class File(object):
         return self.fileset
 
     def get_metadata(self, key=None, default=None):
-        """Get metadata associated to scan.
+        """Get metadata associated with scan.
 
         Parameters
         ----------
@@ -523,7 +523,7 @@ class File(object):
         raise NotImplementedError
 
     def set_metadata(self, data, value=None):
-        """Get metadata associated to scan.
+        """Get metadata associated with scan.
 
         If value is ``None``, scan metadata is set to data.
         If value is not ``None`` data is a key and is set to value.

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -338,14 +338,43 @@ def require_authentication(method):
     return wrapper
 
 
-def _get_fsdb_and_scan(obj, *args) -> tuple["FSDB", "Scan"]:
-    """Retrieve the `FSDB` and the `Scan` instance associated with a given object.
+def _get_fsdb(obj) -> "FSDB":
+    """Retrieve the `FSDB` instance associated with a given object.
 
     Parameters
     ----------
-    obj : Scan or FSDB or Fileset or File
-        Object from which to obtain a ``Scan``. The function determines the
-        appropriate attribute based on the runtime type of ``obj``.
+    obj : FSDB | Scan | Fileset | File
+        Object from which to get the ``FSDB``.
+
+    Returns
+    -------
+    FSDB
+        The ``FSDB`` instance linked to ``obj``.
+
+    Raises
+    ------
+    TypeError
+        If ``obj`` is not an instance of ``FSDB``, ``Scan``, ``Fileset``, or ``File``.
+    """
+    if isinstance(obj, FSDB):
+        return obj
+    elif isinstance(obj, Scan):
+        return obj.db
+    elif isinstance(obj, Fileset):
+        return obj.db
+    elif isinstance(obj, File):
+        return obj.db
+    else:
+        raise TypeError(f"Unsupported object type: {type(obj)}")
+
+
+def _get_fsdb_and_scan(obj, *args) -> tuple["FSDB", "Scan"]:
+    """Retrieve the `FSDB` and the `Scan` instances associated with a given object.
+
+    Parameters
+    ----------
+    obj : FSDB | Scan | Fileset | File
+        Object from which to get the ``FSDB`` and ``Scan`` instances.
     *args : tuple
         Additional positional arguments. When ``obj`` is an ``FSDB``, the first
         element should be the index or key identifying the desired scan.
@@ -363,15 +392,6 @@ def _get_fsdb_and_scan(obj, *args) -> tuple["FSDB", "Scan"]:
         If ``obj`` is not an instance of ``Scan``, ``FSDB``, ``Fileset``, or ``File``.
     plantdb.commons.fsdb.exceptions.ScanNotFoundError
         If ``obj`` is an instance of ``FSDB`` and ``args[0]`` is not an existing ``Scan``.
-
-    Notes
-    -----
-    The dispatch logic is as follows:
-
-    - ``Scan``: returned directly.
-    - ``FSDB``: ``obj.scans[args[0]]`` is accessed; ``args`` must contain at
-      least one element identifying the scan.
-    - ``Fileset`` or ``File``: the ``scan`` attribute of the object is returned.
     """
     if isinstance(obj, Scan):
         return obj.db, obj
@@ -466,13 +486,14 @@ def requires_permission(required_permissions: Union[Permission, Tuple[Permission
                 has_perms = all(
                     db.rbac_manager.can_access_scan(user, metadata, perm) for perm in required_permissions_
                 )
-                # token user have restricted permissions per dataset
+                # Token users have restricted permissions per dataset
                 if isinstance(user, TokenUser):
                     token_permissions = user.get_permissions_for_dataset(scan.id)
                     has_perms = has_perms and all(perm in token_permissions for perm in required_permissions_)
 
             else:
-                has_perms = all(self.rbac_manager.has_permission(user, perm) for perm in required_permissions_)
+                db = _get_fsdb(self)
+                has_perms = all(db.rbac_manager.has_permission(user, perm) for perm in required_permissions_)
 
             if not has_perms:
                 raise PermissionError(

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -132,7 +132,8 @@ from plantdb.commons.fsdb.file_ops import _make_fileset
 from plantdb.commons.fsdb.file_ops import _make_scan
 from plantdb.commons.fsdb.file_ops import _store_scan
 from plantdb.commons.fsdb.lock import LockType
-from plantdb.commons.fsdb.lock import ScanLockManager
+from plantdb.commons.fsdb.lock import LockManager
+from plantdb.commons.fsdb.lock import LockLevel
 from plantdb.commons.fsdb.metadata import MetadataManager
 from plantdb.commons.fsdb.metadata import _get_metadata
 from plantdb.commons.fsdb.metadata import _set_metadata
@@ -603,8 +604,8 @@ class FSDB(db.DB):
         self.is_connected: bool = False
         self.required_filesets = required_filesets or ['metadata']
 
-        # Initialize scan lock manager
-        self.lock_manager = ScanLockManager(basedir)
+        # Initialize lock manager
+        self.lock_manager = LockManager(basedir)
 
         # Initialize the session manager
         if session_manager is None:
@@ -837,7 +838,7 @@ class FSDB(db.DB):
         plantdb.commons.fsdb.ScanNotFoundError: Unknown scan id 'unknown'!
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
-        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, current_user.username):
+        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, current_user.username, LockLevel.SCAN):
             if not self.scan_exists(scan_id):
                 ScanNotFoundError(self, scan_id)
             return self.scans[scan_id]
@@ -926,7 +927,7 @@ class FSDB(db.DB):
 
         # Use exclusive lock for scan creation
         self.logger.debug(f"Creating a scan '{scan_id}' as user '{current_user.username}'...")
-        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, current_user.username):
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, current_user.username, LockLevel.SCAN):
             # Initialize scan object
             scan = Scan(self, scan_id)  # Initialize a new Scan instance
             scan_path = _make_scan(scan)  # Create directory structure
@@ -988,7 +989,7 @@ class FSDB(db.DB):
         """
         # Use exclusive lock for scan deletion
         self.logger.debug(f"Deleting scan '{scan_id}' as '{current_user.username}' user...")
-        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, current_user.username):
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, current_user.username, LockLevel.SCAN):
             # Get the Scan instance from the database
             scan = self.scans[scan_id]
             _delete_scan(scan)  # delete the scan directory
@@ -1061,7 +1062,7 @@ class FSDB(db.DB):
         dict
             Dictionary with lock status information
         """
-        return self.lock_manager.get_lock_status(scan_id)
+        return self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
 
     @require_connected_db
     def is_scan_locked(self, scan_id: str) -> bool:
@@ -1881,7 +1882,7 @@ class Scan(db.Scan, MetadataManager):
         """
         # If no owner is defined, set it to the guest user, save it and reload it into the DB
         if 'owner' not in self.metadata:
-            metadata = self.db.rbac_manager.ensure_scan_owner(self.get_metadata())
+            metadata = self.db.rbac_manager.ensure_scan_owner(self.metadata)
             _set_metadata(self.metadata, metadata, None)
             _store_scan_metadata(self)
             self.db.reload(self.id)
@@ -1995,7 +1996,10 @@ class Scan(db.Scan, MetadataManager):
 
         return self.filesets[fs_id]
 
-    def get_metadata(self, key=None, default={}):
+    @get_authentication
+    @require_authentication
+    @requires_permission(Permission.READ, check_scan_access=False)
+    def get_metadata(self, key=None, default={}, current_user=None, **kwargs):
         """Get the metadata associated with a scan.
 
         Parameters
@@ -2012,16 +2016,14 @@ class Scan(db.Scan, MetadataManager):
             If `key` is ``None``, returns a dictionary.
             Else, returns the value attached to this key.
         """
-        # TODO: should probably create a `@retrieve_username` decorator to provide it to method that do not require a username but could use it
-        # TODO: Or maybe get rid of the lock_manager here?
-        # with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username or "guest"):
-        #    return _get_metadata(self.metadata, key, default)
-
         # Use shared lock for read operations
-        with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, self.db.get_guest_user().username):
+        with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username, LockLevel.SCAN):
             return _get_metadata(self.metadata, key, default)
 
-    def get_measures(self, key=None):
+    @get_authentication
+    @require_authentication
+    @requires_permission(Permission.READ, check_scan_access=True)
+    def get_measures(self, key=None, current_user=None, **kwargs):
         """Get the manual measurements associated with a scan.
 
         Parameters
@@ -2040,7 +2042,9 @@ class Scan(db.Scan, MetadataManager):
         These manual measurements should be a JSON file named `measures.json`.
         It is located at the root folder of the scan dataset.
         """
-        return _get_metadata(self.measures, key, default={})
+        # Use shared lock for read operations
+        with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username, LockLevel.SCAN):
+            return _get_metadata(self.measures, key, default={})
 
     @get_authentication
     @require_authentication
@@ -2087,6 +2091,7 @@ class Scan(db.Scan, MetadataManager):
         {'test': 'value'}
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
+        # The locking mechanism is handled by the `MetadataManager._update_metadata` method
         self._update_metadata(data, value, current_user, _store_scan_metadata, cls_name="Scan")
 
     @get_authentication
@@ -2114,7 +2119,7 @@ class Scan(db.Scan, MetadataManager):
 
         # Use exclusive lock for metadata updates
         self.logger.debug(f"Updating '{self.id}' scan owner to '{new_owner}' user...")
-        with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username, LockLevel.SCAN):
             # Update metadata
             _set_metadata(self.metadata, 'owner', new_owner)
             # Ensure modification timestamp
@@ -2162,7 +2167,7 @@ class Scan(db.Scan, MetadataManager):
         # Use exclusive lock for metadata updates
         valid_groups_str = ", ".join(valid_groups)
         self.logger.debug(f"Updating '{self.id}' scan group sharing to: '{valid_groups_str}'")
-        with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username, LockLevel.SCAN):
             # Update metadata
             _set_metadata(self.metadata, 'sharing', valid_groups)
             # Ensure modification timestamp
@@ -2231,9 +2236,9 @@ class Scan(db.Scan, MetadataManager):
         if self.fileset_exists(fs_id):
             raise FilesetExistsError(self, fs_id)
 
-        # Use exclusive lock for fileset creation
+        # Use fileset-level exclusive lock for fileset creation
         self.logger.debug(f"Creating a fileset '{fs_id}' in scan '{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.id}/{fs_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILESET):
             # Create the new Fileset
             fileset = Fileset(self, fs_id)  # Initialize a new Fileset instance
             _make_fileset(fileset)  # Create directory structure
@@ -2296,7 +2301,7 @@ class Scan(db.Scan, MetadataManager):
 
         # Use exclusive lock for fileset deletion
         self.logger.debug(f"Deleting fileset '{fs_id}' from scan '{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.id}/{fs_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILESET):
             fs = self.filesets[fs_id]
             _delete_fileset(fs)  # delete the fileset
             self.filesets.pop(fs_id)  # remove the Fileset instance from the scan
@@ -2362,8 +2367,8 @@ class Fileset(db.Fileset, MetadataManager):
     """Implement ``Fileset`` for the local *File System DataBase* from the abstract class ``db.Fileset``.
 
     Implementation of a fileset as a simple files structure with:
-      * directory ``${FSDB.basedir}/${FSDB.scan.id}/${Fileset.id}`` containing set of files;
-      * directory ``${FSDB.basedir}/${FSDB.scan.id}/metadata`` containing JSON metadata associated to files;
+      * directory ``${FSDB.basedir}/${FSDB.scan.id}/${Fileset.id}`` containing a set of files;
+      * directory ``${FSDB.basedir}/${FSDB.scan.id}/metadata`` containing JSON metadata associated with files;
       * JSON file ``files.json`` containing the list of files from fileset;
 
     Attributes
@@ -2403,7 +2408,7 @@ class Fileset(db.Fileset, MetadataManager):
         self.logger = self.db.logger
 
     def _erase(self):
-        """Erase the files and metadata associated to this fileset."""
+        """Erase the files and metadata associated with this fileset."""
         for f_id, f in self.files.items():
             f._erase()
         # Reinitialize the attributes
@@ -2501,7 +2506,10 @@ class Fileset(db.Fileset, MetadataManager):
 
         return self.files[f_id]
 
-    def get_metadata(self, key=None, default={}):
+    @get_authentication
+    @require_authentication
+    @requires_permission(Permission.READ, check_scan_access=True)
+    def get_metadata(self, key=None, default={}, current_user=None, **kwargs):
         """Get the metadata associated with a fileset.
 
         Parameters
@@ -2509,7 +2517,7 @@ class Fileset(db.Fileset, MetadataManager):
         key : str
             A key that should exist in the fileset's metadata.
         default : Any, optional
-            The default value to return if the key do not exist in the metadata.
+            The default value to return if the key does not exist in the metadata.
             Default is an empty dictionary``{}``.
 
         Returns
@@ -2538,7 +2546,9 @@ class Fileset(db.Fileset, MetadataManager):
         >>> db._is_dummy=True
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
-        return _get_metadata(self.metadata, key, default)
+        # Use shared lock for read operations
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}", LockType.SHARED, current_user.username, LockLevel.FILESET):
+            return _get_metadata(self.metadata, key, default)
 
     @get_authentication
     @require_authentication
@@ -2576,6 +2586,7 @@ class Fileset(db.Fileset, MetadataManager):
         {'test': 'value'}
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
+        # The locking mechanism is handled by the `MetadataManager._update_metadata` method
         self._update_metadata(data, value, current_user, _store_fileset_metadata, cls_name="Fileset")
 
     @get_authentication
@@ -2619,7 +2630,7 @@ class Fileset(db.Fileset, MetadataManager):
         >>> new_f = fs.create_file('file_007')
         >>> fs.list_files()
         ['dummy_image', 'test_image', 'test_json', 'file_007']
-        >>> print([f.name for f in fs.path().iterdir()])  # the file only exist in the database, not on drive!
+        >>> print([f.name for f in fs.path().iterdir()])  # the file only exists in the database, not on drive!
         ['dummy_image.png', 'test_json.json', 'test_image.png']
         >>> md = {"Name": "Bond, James Bond"}  # Create an example dictionary to save as JSON
         >>> from plantdb.commons import io
@@ -2636,9 +2647,9 @@ class Fileset(db.Fileset, MetadataManager):
         if self.file_exists(f_id):
             raise FileExistsError(self, f_id)
 
-        # Use exclusive lock for file creation
+        # Use file-level exclusive lock for file creation
         self.logger.debug(f"Creating a file '{f_id}' in '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}/{f_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
             # Create the new File
             file = File(self, f_id)  # Initialize a new File instance
 
@@ -2653,7 +2664,7 @@ class Fileset(db.Fileset, MetadataManager):
             _set_metadata(file.metadata, initial_metadata, None)  # add metadata dictionary to the new scan
             _store_file_metadata(file)
 
-            self.files.update({f_id: file})  # Update filesets's files dictionary
+            self.files.update({f_id: file})  # Update filesets's file dictionary
             self.store()  # Store fileset instance to the JSON
 
         self.logger.debug(f"Done creating the file.")
@@ -2705,7 +2716,7 @@ class Fileset(db.Fileset, MetadataManager):
 
         # Use exclusive lock for fileset creation
         self.logger.debug(f"Deleting file '{f_id}' from '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}/{f_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
             f = self.files[f_id]
             _delete_file(f)  # delete the file
             self.files.pop(f_id)  # remove the File instance from the fileset
@@ -2816,7 +2827,10 @@ class File(db.File, MetadataManager):
         self.metadata = {}
         return
 
-    def get_metadata(self, key=None, default={}):
+    @get_authentication
+    @require_authentication
+    @requires_permission(Permission.READ, check_scan_access=True)
+    def get_metadata(self, key=None, default={}, current_user=None, **kwargs):
         """Get the metadata associated with a file.
 
         Parameters
@@ -2824,7 +2838,7 @@ class File(db.File, MetadataManager):
         key : str
             A key that should exist in the file's metadata.
         default : Any, optional
-            The default value to return if the key do not exist in the metadata.
+            The default value to return if the key does not exist in the metadata.
             Default is an empty dictionary``{}``.
 
         Returns
@@ -2845,7 +2859,9 @@ class File(db.File, MetadataManager):
         {'random json': True}
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
-        return _get_metadata(self.metadata, key, default)
+        # Use shared lock for read operations
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.SHARED, current_user.username, LockLevel.FILE):
+            return _get_metadata(self.metadata, key, default)
 
     @get_authentication
     @require_authentication
@@ -2878,6 +2894,7 @@ class File(db.File, MetadataManager):
         {'random json': True, 'test': 'value'}
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
+        # The locking mechanism is handled by the `MetadataManager._update_metadata` method
         self._update_metadata(data, value, current_user, _store_file_metadata, cls_name="File")
 
     @get_authentication
@@ -2914,7 +2931,7 @@ class File(db.File, MetadataManager):
         # Use exclusive lock for this operation
         self.logger.debug(
             f"Importing file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
-        with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
             # Get the file name and extension
             ext = path.suffix[1:]
             self.filename = _get_filename(self, ext)
@@ -2992,10 +3009,10 @@ class File(db.File, MetadataManager):
         ['dummy_image.png', 'test_json.json', 'test_image.png', 'file_007.json']
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
-        # Use exclusive lock for this operation
+        # Use file-level exclusive lock for this operation
         self.logger.debug(
             f"Writing raw file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
-        with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
             self.filename = _get_filename(self, ext)
             path = _file_path(self)
             with path.open(mode="wb") as f:
@@ -3073,7 +3090,7 @@ class File(db.File, MetadataManager):
         # Use exclusive lock for this operation
         self.logger.debug(
             f"Writing file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
-        with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
             self.filename = _get_filename(self, ext)
             path = _file_path(self)
             with path.open(mode="w") as f:

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -645,8 +645,10 @@ class FSDB(db.DB):
             )
 
         # Initialize RBAC manager with groups file in basedir
-        users_file = os.path.join(basedir, "users.json")
-        groups_file = os.path.join(basedir, "groups.json")
+        users_file = basedir / "users.json"
+        users_file.touch(exist_ok=True)  # create the file if missing
+        groups_file = basedir / "groups.json"
+        groups_file.touch(exist_ok=True)  # create the file if missing
         self.rbac_manager = RBACManager(users_file, groups_file, max_login_attempts, lockout_duration)
 
     def path(self) -> pathlib.Path:

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -1972,10 +1972,6 @@ class Scan(db.Scan, MetadataManager):
         Fileset
             The retrieved or created fileset.
 
-        Notes
-        -----
-        If the `id` do not exist in the local database and `create` is `False`, `None` is returned.
-
         Examples
         --------
         >>> from plantdb.commons.test_database import dummy_db
@@ -1994,16 +1990,10 @@ class Scan(db.Scan, MetadataManager):
         None
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
-        # TODO: should probably create a `@retrieve_username` decorator to provide it to method that do not require a username but could use it
-        # TODO: Or maybe get rid of the lock_manager here?
-        # with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username or "guest"):
+        if not self.fileset_exists(fs_id):
+            raise FilesetNotFoundError(self, fs_id)
 
-        # Use shared lock for read operations
-        with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, self.db.get_guest_user().username):
-            if not self.fileset_exists(fs_id):
-                raise FilesetNotFoundError(self, fs_id)
-
-            return self.filesets[fs_id]
+        return self.filesets[fs_id]
 
     def get_metadata(self, key=None, default={}):
         """Get the metadata associated with a scan.
@@ -2032,7 +2022,7 @@ class Scan(db.Scan, MetadataManager):
             return _get_metadata(self.metadata, key, default)
 
     def get_measures(self, key=None):
-        """Get the manual measurements associated to a scan.
+        """Get the manual measurements associated with a scan.
 
         Parameters
         ----------
@@ -2506,19 +2496,13 @@ class Fileset(db.Fileset, MetadataManager):
         >>> img = read_image(f)
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
-        # TODO: should probably create a `@retrieve_username` decorator to provide it to method that do not require a username but could use it
-        # TODO: Or maybe get rid of the lock_manager here?
-        # with self.db.lock_manager.acquire_lock(self.scan.id, LockType.SHARED, current_user.username or "guest"):
+        if not self.file_exists(f_id):
+            raise FileNotFoundError(self, f_id)
 
-        # Use shared lock for read operations
-        with self.db.lock_manager.acquire_lock(self.scan.id, LockType.SHARED, self.db.get_guest_user().username):
-            if not self.file_exists(f_id):
-                raise FileNotFoundError(self, f_id)
-
-            return self.files[f_id]
+        return self.files[f_id]
 
     def get_metadata(self, key=None, default={}):
-        """Get the metadata associated to a fileset.
+        """Get the metadata associated with a fileset.
 
         Parameters
         ----------

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -1234,8 +1234,8 @@ class FSDB(db.DB):
 
     @get_authentication
     @require_authentication
-    @requires_permission(Permission.MANAGE_USERS, check_scan_access=False)
-    def create_user(self, new_username, fullname, password, roles=None, **kwargs) -> None:
+    def create_user(self, new_username, fullname, password, roles=None,
+                    current_user: User | TokenUser | None = None, **kwargs) -> None:
         """Create a new user with the specified details.
 
         Parameters
@@ -1247,17 +1247,20 @@ class FSDB(db.DB):
         password : str
             The password for the new user.
         roles : list[str], optional
-            A list of roles to assign to the new user. Default is None.
+            A list of roles to assign to the new user. Default is ``None``.
+        current_user : User | TokenUser | None
+            The current user, based on logged status or provided API token.
+            Default is ``None``.
 
         Raises
         ------
         PermissionError
             If no user is authenticated.
-            If the user lacks permission to create groups.
+            If the `current_user` lacks permission to create new users.
 
         See Also
         --------
-        RBACManager.users.create : Method used to actually create the user.
+        RBACManager.create_user : Method used to actually create the user.
 
         Examples
         --------
@@ -1274,7 +1277,8 @@ class FSDB(db.DB):
         WoBlNjJPmJHEwuFG3NAyrFtKMHnEg-BRjSplJU-uMbU
         >>> db.disconnect()
         """
-        return self.rbac_manager.users.create(new_username, fullname, password, roles)
+        _ = self.rbac_manager.create_user(current_user, new_username, fullname, password, roles)
+        return
 
     @get_authentication
     @require_authentication
@@ -1296,11 +1300,11 @@ class FSDB(db.DB):
         ------
         PermissionError
             If no user is authenticated, that is logged in or provided an API token.
-            If the user lacks permission to create groups.
+            If the user lacks permissions.
 
         See Also
         --------
-        RBACManager.users.create : Method used to actually create the user.
+        RBACManager.users.update_password : Method used to actually update the user's password.
 
         Examples
         --------
@@ -1456,7 +1460,10 @@ class FSDB(db.DB):
         if username:
             return self.rbac_manager.users.get_user(username)
         elif token:
-            return self.rbac_manager.users.get_user_from_decoded_token(self.session_manager.validate_session(token))
+            if isinstance(self.session_manager, SingleSessionManager):
+                return self.rbac_manager.users.get_user(self.session_manager.validate_session(token)['username'])
+            else:
+                return self.rbac_manager.users.get_user_from_decoded_token(self.session_manager.validate_session(token))
         else:
             self.logger.error("No username or token provided")
             return None
@@ -1504,7 +1511,7 @@ class FSDB(db.DB):
         >>> db = dummy_db()  # automatic login as 'admin'
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
-        >>> prin(group_a.users)
+        >>> print(group_a.users)
         {'admin', 'batman'}
         >>> db.disconnect()
         """

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -2243,7 +2243,8 @@ class Scan(db.Scan, MetadataManager):
 
         # Use fileset-level exclusive lock for fileset creation
         self.logger.debug(f"Creating a fileset '{fs_id}' in scan '{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(f"{self.id}/{fs_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILESET):
+        with self.db.lock_manager.acquire_lock(f"{self.id}/{fs_id}", LockType.EXCLUSIVE, current_user.username,
+                                               LockLevel.FILESET):
             # Create the new Fileset
             fileset = Fileset(self, fs_id)  # Initialize a new Fileset instance
             _make_fileset(fileset)  # Create directory structure
@@ -2306,7 +2307,8 @@ class Scan(db.Scan, MetadataManager):
 
         # Use exclusive lock for fileset deletion
         self.logger.debug(f"Deleting fileset '{fs_id}' from scan '{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(f"{self.id}/{fs_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILESET):
+        with self.db.lock_manager.acquire_lock(f"{self.id}/{fs_id}", LockType.EXCLUSIVE, current_user.username,
+                                               LockLevel.FILESET):
             fs = self.filesets[fs_id]
             _delete_fileset(fs)  # delete the fileset
             self.filesets.pop(fs_id)  # remove the Fileset instance from the scan
@@ -2552,7 +2554,8 @@ class Fileset(db.Fileset, MetadataManager):
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
         # Use shared lock for read operations
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}", LockType.SHARED, current_user.username, LockLevel.FILESET):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}", LockType.SHARED, current_user.username,
+                                               LockLevel.FILESET):
             return _get_metadata(self.metadata, key, default)
 
     @get_authentication
@@ -2653,8 +2656,10 @@ class Fileset(db.Fileset, MetadataManager):
             raise FileExistsError(self, f_id)
 
         # Use file-level exclusive lock for file creation
-        self.logger.debug(f"Creating a file '{f_id}' in '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}/{f_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
+        self.logger.debug(
+            f"Creating a file '{f_id}' in '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}/{f_id}", LockType.EXCLUSIVE,
+                                               current_user.username, LockLevel.FILE):
             # Create the new File
             file = File(self, f_id)  # Initialize a new File instance
 
@@ -2720,8 +2725,10 @@ class Fileset(db.Fileset, MetadataManager):
             raise ValueError(f"File '{f_id}' does not exist in '{self.scan.id}/{self.id}'")
 
         # Use exclusive lock for fileset creation
-        self.logger.debug(f"Deleting file '{f_id}' from '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}/{f_id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
+        self.logger.debug(
+            f"Deleting file '{f_id}' from '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.id}/{f_id}", LockType.EXCLUSIVE,
+                                               current_user.username, LockLevel.FILE):
             f = self.files[f_id]
             _delete_file(f)  # delete the file
             self.files.pop(f_id)  # remove the File instance from the fileset
@@ -2865,7 +2872,8 @@ class File(db.File, MetadataManager):
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
         # Use shared lock for read operations
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.SHARED, current_user.username, LockLevel.FILE):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.SHARED,
+                                               current_user.username, LockLevel.FILE):
             return _get_metadata(self.metadata, key, default)
 
     @get_authentication
@@ -2936,7 +2944,8 @@ class File(db.File, MetadataManager):
         # Use exclusive lock for this operation
         self.logger.debug(
             f"Importing file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE,
+                                               current_user.username, LockLevel.FILE):
             # Get the file name and extension
             ext = path.suffix[1:]
             self.filename = _get_filename(self, ext)
@@ -3017,7 +3026,8 @@ class File(db.File, MetadataManager):
         # Use file-level exclusive lock for this operation
         self.logger.debug(
             f"Writing raw file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE,
+                                               current_user.username, LockLevel.FILE):
             self.filename = _get_filename(self, ext)
             path = _file_path(self)
             with path.open(mode="wb") as f:
@@ -3095,7 +3105,8 @@ class File(db.File, MetadataManager):
         # Use exclusive lock for this operation
         self.logger.debug(
             f"Writing file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
-        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE, current_user.username, LockLevel.FILE):
+        with self.db.lock_manager.acquire_lock(f"{self.scan.id}/{self.fileset.id}/{self.id}", LockType.EXCLUSIVE,
+                                               current_user.username, LockLevel.FILE):
             self.filename = _get_filename(self, ext)
             path = _file_path(self)
             with path.open(mode="w") as f:

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -643,7 +643,7 @@ class FSDB(db.DB):
             # Initialize scan discovery
             self.scans = _load_scans(self)
             self.is_connected = True
-            self.logger.info("Connected to database successfully")
+            self.logger.info("Successfully connected to the database")
         except Exception as e:
             self.logger.error(f"Failed to connect to database: {e}")
             raise
@@ -925,7 +925,7 @@ class FSDB(db.DB):
                 raise ValueError("One or more sharing groups do not exist")
 
         # Use exclusive lock for scan creation
-        self.logger.info(f"Creating a scan '{scan_id}' as user '{current_user.username}'...")
+        self.logger.debug(f"Creating a scan '{scan_id}' as user '{current_user.username}'...")
         with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, current_user.username):
             # Initialize scan object
             scan = Scan(self, scan_id)  # Initialize a new Scan instance
@@ -936,7 +936,7 @@ class FSDB(db.DB):
             scan.store()  # store the new scan in the local database
             self.scans[scan_id] = scan  # Update scans dictionary with the new one
 
-        self.logger.info(f"Done creating scan.")
+        self.logger.debug(f"Done creating scan.")
         return scan
 
     @require_connected_db
@@ -987,14 +987,14 @@ class FSDB(db.DB):
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
         # Use exclusive lock for scan deletion
-        self.logger.info(f"Deleting scan '{scan_id}' as '{current_user.username}' user...")
+        self.logger.debug(f"Deleting scan '{scan_id}' as '{current_user.username}' user...")
         with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, current_user.username):
             # Get the Scan instance from the database
             scan = self.scans[scan_id]
             _delete_scan(scan)  # delete the scan directory
             self.scans.pop(scan_id)  # remove the scan from the scan list
 
-        self.logger.info(f"Done deleting scan.")
+        self.logger.debug(f"Done deleting scan.")
         return True
 
     @require_connected_db
@@ -1189,7 +1189,7 @@ class FSDB(db.DB):
                         self.logger.error(f"Failed to login as '{username}'! Another user is logged in.")
                         return None
                     else:
-                        self.logger.info(f"Already logged in as '{username}'.")
+                        self.logger.warning(f"Already logged in as '{username}'.")
                         return
 
             # Else try to create a new session:
@@ -1199,7 +1199,7 @@ class FSDB(db.DB):
             except AssertionError:
                 self.logger.warning(f"User '{username}' has reached max concurrent sessions")
             else:
-                self.logger.info(f"Successfully logged in as '{username}'.")
+                self.logger.debug(f"Successfully logged in as '{username}'.")
             return session_token
         else:
             self.logger.error(f"Failed to login as '{username}'!")
@@ -1221,7 +1221,7 @@ class FSDB(db.DB):
         """
         success, username = self.session_manager.invalidate_session(kwargs.get('token', None))
         if success:
-            self.logger.info(f"Successfully logged out from '{username}'.")
+            self.logger.debug(f"Successfully logged out from '{username}'.")
             return success, username
         else:
             self.logger.warning(f"Failed to logout!")
@@ -1398,7 +1398,7 @@ class FSDB(db.DB):
         """
         if username and token:
             self.logger.warning("Trying to retrieve user data from both 'username' and token!")
-            self.logger.info("Using 'token' to access user data.")
+            self.logger.debug("Using 'token' to access user data.")
             username = None
 
         if username:
@@ -2123,7 +2123,7 @@ class Scan(db.Scan, MetadataManager):
             return
 
         # Use exclusive lock for metadata updates
-        self.logger.info(f"Updating '{self.id}' scan owner to '{new_owner}' user...")
+        self.logger.debug(f"Updating '{self.id}' scan owner to '{new_owner}' user...")
         with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
             # Update metadata
             _set_metadata(self.metadata, 'owner', new_owner)
@@ -2131,7 +2131,7 @@ class Scan(db.Scan, MetadataManager):
             _set_metadata(self.metadata, 'last_modified', iso_date_now())
             _store_scan_metadata(self)
 
-        self.logger.info(f"Done updating the scan owner.")
+        self.logger.debug(f"Done updating the scan owner.")
         return
 
     @get_authentication
@@ -2171,7 +2171,7 @@ class Scan(db.Scan, MetadataManager):
 
         # Use exclusive lock for metadata updates
         valid_groups_str = ", ".join(valid_groups)
-        self.logger.info(f"Updating '{self.id}' scan group sharing to: '{valid_groups_str}'")
+        self.logger.debug(f"Updating '{self.id}' scan group sharing to: '{valid_groups_str}'")
         with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
             # Update metadata
             _set_metadata(self.metadata, 'sharing', valid_groups)
@@ -2179,7 +2179,7 @@ class Scan(db.Scan, MetadataManager):
             _set_metadata(self.metadata, 'last_modified', iso_date_now())
             _store_scan_metadata(self)
 
-        self.logger.info(f"Done updating the scan group sharing.")
+        self.logger.debug(f"Done updating the scan group sharing.")
         return
 
     @get_authentication
@@ -2242,7 +2242,7 @@ class Scan(db.Scan, MetadataManager):
             raise FilesetExistsError(self, fs_id)
 
         # Use exclusive lock for fileset creation
-        self.logger.info(f"Creating a fileset '{fs_id}' in scan '{self.id}' as '{current_user.username}' user...")
+        self.logger.debug(f"Creating a fileset '{fs_id}' in scan '{self.id}' as '{current_user.username}' user...")
         with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
             # Create the new Fileset
             fileset = Fileset(self, fs_id)  # Initialize a new Fileset instance
@@ -2262,7 +2262,7 @@ class Scan(db.Scan, MetadataManager):
             self.filesets.update({fs_id: fileset})  # Update scan's filesets dictionary
             self.store()  # Store fileset instance to the JSON
 
-        self.logger.info(f"Done creating the fileset.")
+        self.logger.debug(f"Done creating the fileset.")
         return fileset
 
     @get_authentication
@@ -2305,14 +2305,14 @@ class Scan(db.Scan, MetadataManager):
             raise ValueError(f"Fileset '{fs_id}' does not exist in scan '{self.id}'")
 
         # Use exclusive lock for fileset deletion
-        self.logger.info(f"Deleting fileset '{fs_id}' from scan '{self.id}' as '{current_user.username}' user...")
+        self.logger.debug(f"Deleting fileset '{fs_id}' from scan '{self.id}' as '{current_user.username}' user...")
         with self.db.lock_manager.acquire_lock(self.id, LockType.EXCLUSIVE, current_user.username):
             fs = self.filesets[fs_id]
             _delete_fileset(fs)  # delete the fileset
             self.filesets.pop(fs_id)  # remove the Fileset instance from the scan
             self.store()  # save the changes to the scan main JSON FILE (``files.json``)
 
-        self.logger.info(f"Done deleting fileset.")
+        self.logger.debug(f"Done deleting fileset.")
         return
 
     def store(self):
@@ -2653,7 +2653,7 @@ class Fileset(db.Fileset, MetadataManager):
             raise FileExistsError(self, f_id)
 
         # Use exclusive lock for file creation
-        self.logger.info(f"Creating a file '{f_id}' in '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
+        self.logger.debug(f"Creating a file '{f_id}' in '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
         with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
             # Create the new File
             file = File(self, f_id)  # Initialize a new File instance
@@ -2672,7 +2672,7 @@ class Fileset(db.Fileset, MetadataManager):
             self.files.update({f_id: file})  # Update filesets's files dictionary
             self.store()  # Store fileset instance to the JSON
 
-        self.logger.info(f"Done creating the file.")
+        self.logger.debug(f"Done creating the file.")
         return file
 
     @get_authentication
@@ -2720,14 +2720,14 @@ class Fileset(db.Fileset, MetadataManager):
             raise ValueError(f"File '{f_id}' does not exist in '{self.scan.id}/{self.id}'")
 
         # Use exclusive lock for fileset creation
-        self.logger.info(f"Deleting file '{f_id}' from '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
+        self.logger.debug(f"Deleting file '{f_id}' from '{self.scan.id}/{self.id}' as '{current_user.username}' user...")
         with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
             f = self.files[f_id]
             _delete_file(f)  # delete the file
             self.files.pop(f_id)  # remove the File instance from the fileset
             self.store()  # save the changes to the scan main JSON FILE (``files.json``)
 
-        self.logger.info(f"Done deleting file.")
+        self.logger.debug(f"Done deleting file.")
         return
 
     def store(self):
@@ -2928,7 +2928,7 @@ class File(db.File, MetadataManager):
             raise ValueError(f"The provided path is not a file: {path}.")
 
         # Use exclusive lock for this operation
-        self.logger.info(
+        self.logger.debug(
             f"Importing file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
         with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
             # Get the file name and extension
@@ -2940,7 +2940,7 @@ class File(db.File, MetadataManager):
             copyfile(path, newpath)
             self.store()  # register it to the scan main JSON FILE
 
-        self.logger.info(f"Done importing file.")
+        self.logger.debug(f"Done importing file.")
         return
 
     def store(self):
@@ -3009,7 +3009,7 @@ class File(db.File, MetadataManager):
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
         # Use exclusive lock for this operation
-        self.logger.info(
+        self.logger.debug(
             f"Writing raw file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
         with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
             self.filename = _get_filename(self, ext)
@@ -3018,7 +3018,7 @@ class File(db.File, MetadataManager):
                 f.write(data)
             self.store()
 
-        self.logger.info(f"Done writing raw file.")
+        self.logger.debug(f"Done writing raw file.")
         return
 
     def read(self):
@@ -3087,7 +3087,7 @@ class File(db.File, MetadataManager):
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
         """
         # Use exclusive lock for this operation
-        self.logger.info(
+        self.logger.debug(
             f"Writing file '{self.id}' in '{self.scan.id}/{self.fileset.id}' as user '{current_user.username}'...")
         with self.db.lock_manager.acquire_lock(self.scan.id, LockType.EXCLUSIVE, current_user.username):
             self.filename = _get_filename(self, ext)
@@ -3096,7 +3096,7 @@ class File(db.File, MetadataManager):
                 f.write(data)
             self.store()
 
-        self.logger.info(f"Done writing file.")
+        self.logger.debug(f"Done writing file.")
         return
 
     def path(self) -> pathlib.Path:

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -131,9 +131,9 @@ from plantdb.commons.fsdb.file_ops import _load_scans
 from plantdb.commons.fsdb.file_ops import _make_fileset
 from plantdb.commons.fsdb.file_ops import _make_scan
 from plantdb.commons.fsdb.file_ops import _store_scan
-from plantdb.commons.fsdb.lock import LockType
-from plantdb.commons.fsdb.lock import LockManager
 from plantdb.commons.fsdb.lock import LockLevel
+from plantdb.commons.fsdb.lock import LockManager
+from plantdb.commons.fsdb.lock import LockType
 from plantdb.commons.fsdb.metadata import MetadataManager
 from plantdb.commons.fsdb.metadata import _get_metadata
 from plantdb.commons.fsdb.metadata import _set_metadata
@@ -185,8 +185,11 @@ def require_token(method):
 
         if isinstance(self.session_manager, SingleSessionManager):
             # If a Single SessionManager, get the token from the session manager
-            session = list(self.session_manager.sessions.keys())[0]
-            kwargs['token'] = session
+            try:
+                session = list(self.session_manager.sessions.keys())[0]
+                kwargs['token'] = session
+            except IndexError:
+                self.logger.error("No logged user!")
 
         elif isinstance(self.session_manager, JWTSessionManager):
             # If a JSON Web Token Session Manager, require the token
@@ -206,7 +209,7 @@ def require_token(method):
     return wrapper
 
 
-def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs):
+def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs) -> User | TokenUser | None:
     """Returns the username of the currently logged user based on the session management system.
 
     This function identifies the username of the logged-in user by inspecting the session manager
@@ -227,7 +230,7 @@ def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs):
 
     Returns
     -------
-    str
+    User | TokenUser | None
         The username of the logged-in user or the fallback `default_user`.
 
     Notes
@@ -1173,17 +1176,15 @@ class FSDB(db.DB):
         >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
         >>> token = db.login('guest', 'guest')
         ERROR    [FSDB] Failed to login as 'guest'! Another user is logged in.
-        >>> db.logout()
-        INFO     [FSDB] User 'admin' logged out successfully.
-        True
+        >>> db.logout()  # log out from 'admin' session
+        (True, 'admin')
         >>> token = db.login('guest', 'guest')
-        [FSDB] Successfully logged in as 'guest'.
         >>> db.disconnect()
         """
         if self.validate_user(username, password):
 
             # If a SingleSessionManager and a currently logged user, abort
-            if isinstance(self.session_manager, SingleSessionManager):
+            if isinstance(self.session_manager, SingleSessionManager) and self.session_manager.has_logged_user():
                 current_username = get_logged_username(self)
                 if current_username:
                     if current_username != username:
@@ -1215,9 +1216,12 @@ class FSDB(db.DB):
         >>> from plantdb.commons.test_database import dummy_db
         >>> db = dummy_db()  # automatic login as 'admin'
         INFO     [FSDB] Successfully logged in as 'admin'.
-        >>> db.logout()
-        INFO     [FSDB] Successfully logged out from 'admin'.
+        >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
+        >>> db.logout()  # log out from NO session
+        ERROR    [FSDB] No logged user!
+        WARNING  [FSDB] Failed to logout!
+        (False, None)
         >>> db.disconnect()
         """
         success, username = self.session_manager.invalidate_session(kwargs.get('token', None))
@@ -1263,9 +1267,11 @@ class FSDB(db.DB):
         INFO     [FSDB] Successfully logged in as 'admin'.
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         INFO     [UserManager] Welcome Bruce Wayne, please log in...'
-        >>> db.logout()
+        >>> db.logout()  # log out from 'admin' session
+        (True, 'admin')
         >>> token = db.login('batman', 'joker')
-        INFO     [FSDB] Successfully logged in as 'batman'.
+        >>> print(token)
+        WoBlNjJPmJHEwuFG3NAyrFtKMHnEg-BRjSplJU-uMbU
         >>> db.disconnect()
         """
         return self.rbac_manager.users.create(new_username, fullname, password, roles)
@@ -1368,9 +1374,9 @@ class FSDB(db.DB):
 
         Parameters
         ----------
-        username : str
+        username : str | None
             The username to retrieve the user data from.
-        token : str
+        token : str | None
             The token provided by the RBAC manager.
 
         Returns
@@ -1388,10 +1394,9 @@ class FSDB(db.DB):
         >>> db = dummy_db()  # automatic login as 'admin'
         >>> db.get_user_data(username='admin')
         User(username='admin', fullname='PlantDB Admin', password_hash='$argon2id$v=19$m=65536,t=3,p=4$zMr0ZhclnHHdOgwWKv3Hbg$SZshbPdNiCdBONb8vgzZAKyWPl5sNIUwB8mQWkzGYOQ', roles={<Role.ADMIN: 'admin'>}, created_at=datetime.datetime(2026, 1, 29, 17, 22, 49, 683163), permissions=None, last_login=datetime.datetime(2026, 1, 29, 17, 22, 49, 770793), is_active=True, failed_attempts=0, last_failed_attempt=None, locked_until=None, password_last_change=datetime.datetime(2026, 1, 29, 17, 22, 49, 683163))
-        >>> db.logout()
-        INFO     [FSDB] Successfully logged out from 'admin'.
+        >>> db.logout()  # log out from 'admin' session
+        (True, 'admin')
         >>> token = db.login('guest', 'guest')
-        INFO     [FSDB] Successfully logged in as 'guest'.
         >>> user_data = db.get_user_data(token=token)
         >>> print(user_data.fullname)
         PlantDB Guest

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -1276,6 +1276,52 @@ class FSDB(db.DB):
         """
         return self.rbac_manager.users.create(new_username, fullname, password, roles)
 
+    @get_authentication
+    @require_authentication
+    def update_user_password(self, old_password: str, new_password: str,
+                             current_user: User | TokenUser | None = None, **kwargs) -> None:
+        """Create a new user with the specified details.
+
+        Parameters
+        ----------
+        old_password : str
+            The password for the user.
+        new_password : str
+            The new password for the user.
+        current_user : User | TokenUser | None
+            The current user, based on logged status or provided API token.
+            Default is ``None``.
+
+        Raises
+        ------
+        PermissionError
+            If no user is authenticated, that is logged in or provided an API token.
+            If the user lacks permission to create groups.
+
+        See Also
+        --------
+        RBACManager.users.create : Method used to actually create the user.
+
+        Examples
+        --------
+        >>> from plantdb.commons.auth.models import Role
+        >>> from plantdb.commons.test_database import dummy_db
+        >>> db = dummy_db()  # automatic login as 'admin'
+        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
+        INFO     [UserManager] Welcome Bruce Wayne, please log in...'
+        >>> db.logout()  # log out from 'admin' session
+        (True, 'admin')
+        >>> token = db.login('batman', 'joker')
+        >>> db.update_user_password('joker', 'alfred')
+        INFO     [UserManager] Password updated for user 'batman'...
+        >>> db.logout()  # log out from 'batman' session
+        (True, 'batman')
+        >>> token = db.login('batman', 'alfred')  # login with new password
+        >>> db.disconnect()
+        """
+        return self.rbac_manager.users.update_password(current_user.username, old_password, new_password)
+
     @require_connected_db
     @get_authentication
     @require_authentication

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -1224,13 +1224,17 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> token = db.login('guest', 'guest')
         ERROR    [FSDB] Failed to login as 'guest'! Another user is logged in.
         >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
         >>> token = db.login('guest', 'guest')
+        >>> print(len(token))
+        43
         >>> db.disconnect()
         """
         if self.validate_user(username, password):
@@ -1266,9 +1270,10 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
         >>> db.logout()  # log out from NO session
@@ -1318,16 +1323,18 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
+        INFO     [RBACManager] User 'admin' is creating new user 'batman' with roles=<Role.CONTRIBUTOR: 'contributor'>.
         INFO     [UserManager] Welcome Bruce Wayne, please log in...'
         >>> db.logout()  # log out from 'admin' session
         (True, 'admin')
         >>> token = db.login('batman', 'joker')
-        >>> print(token)
-        WoBlNjJPmJHEwuFG3NAyrFtKMHnEg-BRjSplJU-uMbU
+        >>> print(len(token))
+        43
         >>> db.disconnect()
         """
         _ = self.rbac_manager.create_user(current_user, new_username, fullname, password, roles)
@@ -1361,10 +1368,10 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        INFO     [FSDB] Successfully logged in as 'admin'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         INFO     [UserManager] Welcome Bruce Wayne, please log in...'
         >>> db.logout()  # log out from 'admin' session
@@ -1375,6 +1382,8 @@ class FSDB(db.DB):
         >>> db.logout()  # log out from 'batman' session
         (True, 'batman')
         >>> token = db.login('batman', 'alfred')  # login with new password
+        >>> print(len(token))
+        43
         >>> db.disconnect()
         """
         return self.rbac_manager.users.update_password(current_user.username, old_password, new_password)
@@ -1384,7 +1393,7 @@ class FSDB(db.DB):
     @require_authentication
     def create_api_token(
             self, token_exp: int,
-            datasets: dict[str, tuple[Permission, ...] | Permission],
+            datasets: dict[str, list[Permission] | Permission],
             current_user: User | None = None, **kwargs
     ) -> str:
         """
@@ -1399,25 +1408,39 @@ class FSDB(db.DB):
         ----------
         token_exp : int
             The expiration duration of the API token in seconds.
-        datasets : dict of str to tuple of Permission or Permission
+        datasets : dict[str, list[Permission] | Permission]
             A dictionary where the keys are dataset names, and the values are either
             a tuple of `Permission` instances or a single `Permission` instance
             defining the access levels for each dataset.
         current_user : plantdb.commons.fsdb.auth.models.User, optional
             The user object representing the currently authenticated user. The username
             from this object is used to associate the API token.
-        **kwargs
-            Additional keyword arguments passed for possible extended functionality.
+
+        Other Parameters
+        ----------------
+        token : str
+            The token to use to authenticate against the ``JWTSessionManager``.
 
         Returns
         -------
         str
             The generated API token.
+
+        Examples
+        --------
+        >>> from plantdb.commons.test_database import test_database
+        >>> from plantdb.commons.auth.session import JWTSessionManager
+        >>> from plantdb.commons.auth.models import Permission
+        >>> db = test_database(session_manager=JWTSessionManager())
+        >>> db.connect()
+        >>> access_token, refresh_token = db.login('admin', 'admin')
+        >>> api_token = db.create_api_token(3600, {'real_plant_analyzed': [Permission.WRITE]}, token=access_token)
+        >>> db.disconnect()
         """
         if not isinstance(self.session_manager, JWTSessionManager):
             raise RuntimeError("Session manager must be an instance of JWTSessionManager.")
-        session_manager: JWTSessionManager = self.session_manager
-        return session_manager.create_api_token(current_user.username, token_exp, datasets)
+
+        return self.session_manager.create_api_token(current_user.username, token_exp, datasets)
 
     def get_guest_user(self) -> User:
         """Retrieve the guest user information from the RBAC manager.
@@ -1460,14 +1483,12 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
-        >>> db.logout()
-        INFO     [FSDB] Successfully logged out from 'admin'.
-        >>> token = db.login('guest', 'guest')
-        INFO     [FSDB] Successfully logged in as 'guest'.
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.get_username(token)
-        'guest'
+        'admin'
         >>> db.disconnect()
         """
         return self.session_manager.session_username(token)
@@ -1493,14 +1514,13 @@ class FSDB(db.DB):
 
         Examples
         --------
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.get_user_data(username='admin')
         User(username='admin', fullname='PlantDB Admin', password_hash='$argon2id$v=19$m=65536,t=3,p=4$zMr0ZhclnHHdOgwWKv3Hbg$SZshbPdNiCdBONb8vgzZAKyWPl5sNIUwB8mQWkzGYOQ', roles={<Role.ADMIN: 'admin'>}, created_at=datetime.datetime(2026, 1, 29, 17, 22, 49, 683163), permissions=None, last_login=datetime.datetime(2026, 1, 29, 17, 22, 49, 770793), is_active=True, failed_attempts=0, last_failed_attempt=None, locked_until=None, password_last_change=datetime.datetime(2026, 1, 29, 17, 22, 49, 683163))
-        >>> db.logout()  # log out from 'admin' session
-        (True, 'admin')
-        >>> token = db.login('guest', 'guest')
-        >>> user_data = db.get_user_data(token=token)
+        >>> user_data = db.get_user_data(username='guest')
         >>> print(user_data.fullname)
         PlantDB Guest
         >>> db.disconnect()
@@ -1560,8 +1580,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1608,8 +1630,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1657,8 +1681,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1703,8 +1729,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print(group_a.users)
@@ -1742,8 +1770,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print([g.name for g in db.list_groups()])
@@ -1784,8 +1814,10 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.auth.models import Role
-        >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # automatic login as 'admin'
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
         >>> db.create_user('batman', 'Bruce Wayne', 'joker', roles=Role.CONTRIBUTOR)
         >>> group_a = db.create_group('groupA', ['batman'], description="The group A.")
         >>> print([g.name for g in db.get_user_groups('batman')])

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -116,6 +116,7 @@ from plantdb.commons.auth.models import TokenUser
 from plantdb.commons.auth.models import User
 from plantdb.commons.auth.rbac import RBACManager
 from plantdb.commons.auth.session import JWTSessionManager
+from plantdb.commons.auth.session import NoAuthSessionManager
 from plantdb.commons.auth.session import SessionManager
 from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.fsdb.exceptions import FileNotFoundError
@@ -252,7 +253,7 @@ def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs) -
     >>> import os
     >>> from plantdb.commons.test_database import dummy_db
     >>> from plantdb.commons.fsdb.core import get_logged_username
-    >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
+    >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
     >>> get_logged_username(db)
     'admin'
     >>> db.logout()
@@ -260,8 +261,8 @@ def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs) -
     True
     >>> get_logged_username(db, default_user='guest')
     """
-    if isinstance(fsdb.session_manager, SingleSessionManager):
-        # If a Single SessionManager, get the username from the session manager (as only one user can be logged at once)
+    if isinstance(fsdb.session_manager, (NoAuthSessionManager, SingleSessionManager)):
+        # Get the username from the session manager (as only one user can be logged at once)
         try:
             session = list(fsdb.session_manager.sessions.keys())[0]
         except IndexError:
@@ -576,7 +577,7 @@ class FSDB(db.DB):
     <class 'plantdb.commons.fsdb.core.Scan'>
     >>> db.disconnect()  # clean up (delete) the temporary dummy database
 
-    >>> # EXAMPLE 2: Use a local database:
+    >>> # EXAMPLE 2: Use a local database with a :
     >>> import os
     >>> from plantdb.commons.fsdb.core import FSDB
     >>> db = FSDB(os.environ.get('ROMI_DB', "/data/ROMI/DB/"), log_level="DEBUG")
@@ -592,7 +593,7 @@ class FSDB(db.DB):
     def __init__(self, basedir: Union[str, Path],
                  required_filesets: Optional[List[str]] = None,
                  logger: Optional[logging.Logger] = None,
-                 session_manager: Union[SingleSessionManager, SessionManager, JWTSessionManager] = None,
+                 session_manager: SessionManager = None,
                  session_timeout: int = 3600, max_login_attempts: int = 3,
                  lockout_duration: int = 900, max_concurrent_sessions: int = 10, **kwargs):
         """Database constructor.
@@ -609,9 +610,9 @@ class FSDB(db.DB):
             Use `[]` to accept any subdirectory of `basedir` as a valid "scan".
         logger : logging.Logger, optional
             Logger instance to use for logging. Defaults to the module logger.
-        session_manager : Union[SingleSessionManager, SessionManager, JWTSessionManager], optional
+        session_manager : SessionManager, optional
             The session manager to use for session authentication.
-            Defaults to ``SingleSessionManager``.
+            Defaults to ``NoAuthSessionManager`` if ``'no_auth'`` kwarg is set to `True``, else ``SingleSessionManager``.
         session_timeout : int, optional
             Session timeout in seconds.
             Defaults to 3600 (1 hour).
@@ -659,15 +660,17 @@ class FSDB(db.DB):
 
         # Initialize the session manager
         if session_manager is None:
-            self.session_manager = SingleSessionManager(
-                session_timeout=session_timeout,
-            )
-        elif isinstance(session_manager, (SingleSessionManager, SessionManager, JWTSessionManager)):
+            if kwargs.get('no_auth', False):
+                self.session_manager = NoAuthSessionManager(session_timeout=session_timeout)
+            else:
+                self.session_manager = SingleSessionManager(session_timeout=session_timeout)
+        elif isinstance(session_manager,
+                        (SingleSessionManager, SessionManager, JWTSessionManager, NoAuthSessionManager)):
             self.session_manager = session_manager
         else:
             raise ValueError(
                 f"session_manager must be an instance of 'SingleSessionManager', 'SessionManager', "
-                f"or 'JWTSessionManager', got {type(session_manager)}"
+                f" 'JWTSessionManager' or 'NoAuthSessionManager', got {type(session_manager)}"
             )
 
         # Initialize RBAC manager with groups file in basedir
@@ -1196,7 +1199,7 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
+        >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
         >>> db.validate_user('guest', 'guest')
         True
         >>> db.disconnect()
@@ -1222,7 +1225,7 @@ class FSDB(db.DB):
         Examples
         --------
         >>> from plantdb.commons.test_database import dummy_db
-        >>> db = dummy_db()  # SingleSessionManager with automatic login as 'admin'
+        >>> db = dummy_db()  # NoAuthSessionManager with automatic login as 'admin'
         >>> token = db.login('guest', 'guest')
         ERROR    [FSDB] Failed to login as 'guest'! Another user is logged in.
         >>> db.logout()  # log out from 'admin' session
@@ -1233,7 +1236,8 @@ class FSDB(db.DB):
         if self.validate_user(username, password):
 
             # If a SingleSessionManager and a currently logged user, abort
-            if isinstance(self.session_manager, SingleSessionManager) and self.session_manager.has_logged_user():
+            if isinstance(self.session_manager,
+                          (NoAuthSessionManager, SingleSessionManager)) and self.session_manager.has_logged_user():
                 current_username = get_logged_username(self)
                 if current_username:
                     if current_username != username:
@@ -1973,7 +1977,7 @@ class Scan(db.Scan, MetadataManager):
         """A property method to retrieve or set the `owner` of a resource.
 
         If the `owner` is not already defined in the resource's metadata, this property
-        ensures that a default owner is assigned (using a guest user). The updated metadata
+        ensures that a default owner is assigned (using the 'guest' user). The updated metadata
         is then stored in the database, and the resource is reloaded.
 
         Returns
@@ -1987,7 +1991,7 @@ class Scan(db.Scan, MetadataManager):
         _store_scan_metadata : Saves updated metadata to the database.
         db.reload : Reloads the resource from the database after updates.
         """
-        # If no owner is defined, set it to the guest user, save it and reload it into the DB
+        # If no owner is defined, set it to the 'guest' user, save it and reload it into the DB
         if 'owner' not in self.metadata:
             metadata = self.db.rbac_manager.ensure_scan_owner(self.metadata)
             _set_metadata(self.metadata, metadata, None)

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -98,6 +98,7 @@ import json
 import logging
 import os
 import pathlib
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 from shutil import copyfile
@@ -676,10 +677,17 @@ class FSDB(db.DB):
                 f" 'JWTSessionManager' or 'NoAuthSessionManager', got {type(session_manager)}"
             )
 
-        # Initialize RBAC manager with groups file in basedir
-        users_file = basedir / "users.json"
+        if isinstance(self.session_manager, NoAuthSessionManager):
+            # Create a temporary directory with empty to avoid enabling access to real user & groups data
+            manager_dir = Path(tempfile.mkdtemp(prefix='plantdb-'))
+        else:
+            # Will use/create the real users & groups JSON files in basedir
+            manager_dir = basedir
+
+        # Initialize RBAC manager with users & groups files
+        users_file = manager_dir / "users.json"
         users_file.touch(exist_ok=True)  # create the file if missing
-        groups_file = basedir / "groups.json"
+        groups_file = manager_dir / "groups.json"
         groups_file.touch(exist_ok=True)  # create the file if missing
         self.rbac_manager = RBACManager(users_file, groups_file, max_login_attempts, lockout_duration)
 

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -101,6 +101,7 @@ import pathlib
 from collections.abc import Iterable
 from pathlib import Path
 from shutil import copyfile
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -145,6 +146,7 @@ from plantdb.commons.fsdb.path_helpers import _fileset_path
 from plantdb.commons.fsdb.path_helpers import _get_filename
 from plantdb.commons.fsdb.path_helpers import _scan_path
 from plantdb.commons.fsdb.validation import _is_valid_id
+from plantdb.commons.log import DEFAULT_LOG_LEVEL
 from plantdb.commons.log import get_logger
 from plantdb.commons.utils import iso_date_now
 
@@ -152,7 +154,7 @@ from plantdb.commons.utils import iso_date_now
 MARKER_FILE_NAME = "romidb"
 
 
-def require_connected_db(method):
+def require_connected_db(method: Callable) -> Callable:
     """Decorator that ensures the method is only called when the database is connected.
 
     This ensures that operations that require a valid database connection are properly guarded against calls when the connection is inactive.
@@ -177,7 +179,7 @@ def require_connected_db(method):
     return wrapper
 
 
-def require_token(method):
+def require_token(method: Callable) -> Callable:
     """Decorator that passes the token to the decorated method depending on the session manager."""
 
     @functools.wraps(method)
@@ -280,7 +282,7 @@ def get_logged_username(fsdb: "FSDB", default_user=None, token=None, **kwargs) -
     return logged_user
 
 
-def get_authentication(method):
+def get_authentication(method: Callable) -> Callable:
     """Get authentication and inject ``current_user`` into the wrapped call.
 
     The wrapper expects the following keyword arguments (all optional):
@@ -325,7 +327,7 @@ def get_authentication(method):
     return wrapper
 
 
-def require_authentication(method):
+def require_authentication(method: Callable) -> Callable:
     """Enforce authentication."""
 
     @functools.wraps(method)
@@ -333,6 +335,24 @@ def require_authentication(method):
         # Abort if no authenticated user could be determined
         if not kwargs.get('current_user'):
             raise NoAuthUserError()
+        return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+def use_guest_as_default(method: Callable) -> Callable:
+    """Injects a guest user when no authentication is provided.
+
+    This enables methods that require an authenticated user to operate transparently with a default guest context.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if not kwargs.get('current_user'):
+            if isinstance(self, (Scan, Fileset, File)):
+                kwargs["current_user"] = self.db.get_guest_user()
+            else:
+                kwargs["current_user"] = self.get_guest_user()
         return method(self, *args, **kwargs)
 
     return wrapper
@@ -559,7 +579,7 @@ class FSDB(db.DB):
     >>> # EXAMPLE 2: Use a local database:
     >>> import os
     >>> from plantdb.commons.fsdb.core import FSDB
-    >>> db = FSDB(os.environ.get('ROMI_DB', "/data/ROMI/DB/"))
+    >>> db = FSDB(os.environ.get('ROMI_DB', "/data/ROMI/DB/"), log_level="DEBUG")
     >>> db.connect()
     >>> token = db.login('guest', 'guest')
     >>> scan_ids = db.list_scans(owner_only=False, token=token)
@@ -574,7 +594,7 @@ class FSDB(db.DB):
                  logger: Optional[logging.Logger] = None,
                  session_manager: Union[SingleSessionManager, SessionManager, JWTSessionManager] = None,
                  session_timeout: int = 3600, max_login_attempts: int = 3,
-                 lockout_duration: int = 900, max_concurrent_sessions: int = 10):
+                 lockout_duration: int = 900, max_concurrent_sessions: int = 10, **kwargs):
         """Database constructor.
 
         Check the given `` basedir `` directory exists and load accessible ``Scan`` objects.
@@ -605,6 +625,11 @@ class FSDB(db.DB):
             The maximum number of concurrent sessions to login before locking up.
             Defaults to 10.
 
+        Other Parameters
+        ----------------
+        log_level : str
+            A logging level to set for the logger. Defaults to ``INFO``.
+
         Raises
         ------
         NotADirectoryError
@@ -617,7 +642,8 @@ class FSDB(db.DB):
         plantdb.commons.fsdb.core.MARKER_FILE_NAME
         """
         super().__init__()
-        self.logger = logger or get_logger(__class__.__name__)
+        self.logger = logger or get_logger(__class__.__name__,
+                                           log_level=kwargs.get('log_level', DEFAULT_LOG_LEVEL))
 
         basedir = Path(basedir)
         # Check the given path to the root directory of the database is a directory:
@@ -2078,7 +2104,7 @@ class Scan(db.Scan, MetadataManager):
         return self.filesets[fs_id]
 
     @get_authentication
-    @require_authentication
+    @use_guest_as_default
     @requires_permission(Permission.READ, check_scan_access=False)
     def get_metadata(self, key=None, default={}, current_user=None, **kwargs):
         """Get the metadata associated with a scan.
@@ -2102,7 +2128,7 @@ class Scan(db.Scan, MetadataManager):
             return _get_metadata(self.metadata, key, default)
 
     @get_authentication
-    @require_authentication
+    @use_guest_as_default
     @requires_permission(Permission.READ, check_scan_access=True)
     def get_measures(self, key=None, current_user=None, **kwargs):
         """Get the manual measurements associated with a scan.
@@ -2590,7 +2616,7 @@ class Fileset(db.Fileset, MetadataManager):
         return self.files[f_id]
 
     @get_authentication
-    @require_authentication
+    @use_guest_as_default
     @requires_permission(Permission.READ, check_scan_access=True)
     def get_metadata(self, key=None, default={}, current_user=None, **kwargs):
         """Get the metadata associated with a fileset.
@@ -2916,7 +2942,7 @@ class File(db.File, MetadataManager):
         return
 
     @get_authentication
-    @require_authentication
+    @use_guest_as_default
     @requires_permission(Permission.READ, check_scan_access=True)
     def get_metadata(self, key=None, default={}, current_user=None, **kwargs):
         """Get the metadata associated with a file.

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -630,6 +630,9 @@ class FSDB(db.DB):
         ----------------
         log_level : str
             A logging level to set for the logger. Defaults to ``INFO``.
+        no_auth : bool
+            A boolean flag to switch between session managers.
+            If ``True``, use `NoAuthSessionManager` else use `SingleSessionManager`.
 
         Raises
         ------
@@ -882,6 +885,7 @@ class FSDB(db.DB):
 
         Examples
         --------
+        >>> # Example #1 - API demo
         >>> from plantdb.commons.test_database import dummy_db
         >>> db = dummy_db(with_scan=True)
         >>> scan = db.get_scan('myscan_001')
@@ -892,6 +896,18 @@ class FSDB(db.DB):
         >>> unknown_scan = db.get_scan('unknown')
         plantdb.commons.fsdb.ScanNotFoundError: Unknown scan id 'unknown'!
         >>> db.disconnect()  # clean up (delete) the temporary dummy database
+
+        >>> # Example #2 - API demo with authentication
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> scan = db.get_scan('real_plant_analyzed')
+        plantdb.commons.fsdb.exceptions.NoAuthUserError: No authenticated user!
+        >>> token = db.login('admin', 'admin')
+        >>> scan = db.get_scan('real_plant_analyzed')
+        >>> print(scan.id)
+        real_plant_analyzed
+        >>> db.disconnect()
         """
         with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, current_user.username, LockLevel.SCAN):
             if not self.scan_exists(scan_id):
@@ -2158,6 +2174,18 @@ class Scan(db.Scan, MetadataManager):
         any
             If `key` is ``None``, returns a dictionary.
             Else, returns the value attached to this key.
+
+        Examples
+        --------
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database()
+        >>> db.connect()
+        >>> token = db.login('admin', 'admin')
+        >>> scan = db.get_scan('real_plant_analyzed')
+        >>> scan.get_metadata('owner')
+        'guest'
+        >>> db.logout()
+        >>> scan.get_metadata('owner')  # Can still access it as 'guest' user
         """
         # Use shared lock for read operations
         with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username, LockLevel.SCAN):

--- a/src/commons/plantdb/commons/fsdb/exceptions.py
+++ b/src/commons/plantdb/commons/fsdb/exceptions.py
@@ -99,9 +99,15 @@ class FileExistsError(Exception):
 class FilesetNoIDError(Exception):
     """No 'id' entry could be found for this fileset."""
 
+    def __init__(self, scan: 'Scan') -> None:
+        super().__init__(f"Missing the 'id' entry for a 'Fileset' in scan '{scan.id}'!")
+
 
 class FileNoIDError(Exception):
     """No 'id' entry could be found for this file."""
+
+    def __init__(self, fs: 'Fileset') -> None:
+        super().__init__(f"Missing the 'id' entry for a 'File' in scan/fileset '{fs.scan.id}/{fs.id}'!.")
 
 
 class FileNoFileNameError(Exception):

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -298,7 +298,7 @@ def _load_scan_filesets(scan):
     {'fsid_001': <plantdb.commons.fsdb.core.Fileset object at 0x7fa0122232d0>}
     """
     filesets = {}
-    # Get the path to the `files.json` associated to the `scan`:
+    # Get the path to the `files.json` associated with the `scan`:
     files_json = _scan_json_file(scan)
     # Load it:
     with files_json.open(mode="r") as f:
@@ -510,7 +510,7 @@ def _delete_file(file):
     Notes
     -----
     We have to delete:
-      - the JSON metadata file associated to the file.
+      - the JSON metadata file associated with the file.
       - the file
 
     See Also
@@ -530,7 +530,7 @@ def _delete_file(file):
         logger.debug(f"File path: '{file_path}'")
         raise IOError("Cannot delete files or directories outside of a local DB.")
 
-    # - Delete the JSON metadata file associated to the `File` instance:
+    # - Delete the JSON metadata file associated with the `File` instance:
     file_md_path = _file_metadata_path(file)
     if file_md_path.is_file():
         try:
@@ -543,7 +543,7 @@ def _delete_file(file):
             logger.info(
                 f"Deleted JSON metadata file for file '{file.id}' from '{file.fileset.scan.id}/{file.fileset.id}'.")
 
-    # - Delete the file associated to the `File` instance:
+    # - Delete the file associated with the `File` instance:
     if file_path.is_file():
         try:
             file_path.unlink(missing_ok=False)
@@ -594,7 +594,7 @@ def _delete_fileset(fileset):
     for f_id in files_list:
         fileset.delete_file(f_id)
 
-    # - Delete the JSON metadata file associated to the `Fileset` instance:
+    # - Delete the JSON metadata file associated with the `Fileset` instance:
     json_md = _fileset_metadata_json_path(fileset)
     try:
         json_md.unlink(missing_ok=False)
@@ -604,7 +604,7 @@ def _delete_fileset(fileset):
     else:
         logger.info(f"Deleted the JSON metadata file for fileset '{fileset.id}'.")
 
-    # - Delete the metadata directory associated to the `Fileset` instance:
+    # - Delete the metadata directory associated with the `Fileset` instance:
     dir_md = _fileset_metadata_path(fileset)
     try:
         rmtree(dir_md, ignore_errors=True)
@@ -614,7 +614,7 @@ def _delete_fileset(fileset):
     else:
         logger.info(f"Deleted metadata directory for fileset '{fileset.id}'.")
 
-    # - Delete the directory associated to the `Fileset` instance:
+    # - Delete the directory associated with the `Fileset` instance:
     try:
         rmtree(fileset_path, ignore_errors=True)
     except:
@@ -708,7 +708,7 @@ def _make_scan(scan) -> pathlib.Path:
 
 
 def _store_scan(scan):
-    """Dump the fileset and files structure associated to a `scan` on drive.
+    """Dump the fileset and files structure associated with a `scan` on drive.
 
     Parameters
     ----------

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -207,8 +207,17 @@ def _load_scans(db):
     if bad_scans:
         n_bad = len(bad_scans)
         logger.info(f"Found {n_bad} bad scans: {', '.join(bad_scans)}")
-        if yes_no_choice(
-                f"Do you want to remove th{'is' if n_bad == 1 else 'ese'} {len(bad_scans)} scan{'' if n_bad == 1 else 's'}?"):
+        try:
+            # Prompt the user only when stdin is available.
+            answer = yes_no_choice(
+                f"Do you want to remove th{'is' if n_bad == 1 else 'ese'} {n_bad} scan{'' if n_bad == 1 else 's'}?"
+            )
+        except EOFError:
+            # No interactive input –> default to **no** (do not delete)
+            logger.debug("EOFError while reading user input, defaulting to “no”.")
+            answer = False
+
+        if answer:
             for scan_name in bad_scans:
                 _delete_scan(Scan(db, scan_name))
 

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -414,9 +414,6 @@ def _load_fileset_files(fileset, fileset_info):
         for n, file_info in enumerate(files_info):
             try:
                 file = _load_file(fileset, file_info)
-                fid = file_info.get("id")
-                if fid is None:
-                    raise FileNotFoundError(f"Missing 'id' for the {n}-th 'files' entry.")
             except FileNoIDError:
                 logger.error(f"Could not get an 'id' entry for the {n}-th 'files' entry from '{scan_id}'.")
                 logger.debug(f"Current `file_info`: {file_info}")
@@ -426,6 +423,7 @@ def _load_fileset_files(fileset, fileset_info):
                 logger.error(f"Could not find file '{fname}' for '{scan_id}/{fs_id}'.")
                 logger.debug(f"Current `file_info`: {file_info}")
             else:
+                fid = file_info.get("id")
                 files[fid] = file
     else:
         raise IOError(f"Expected a list of files in `files.json` from dataset '{fileset.scan.id}'!")

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -324,7 +324,7 @@ def _load_scan_filesets(scan):
     # Get the list of info (dict) about the filesets
     filesets_info = structure["filesets"]
     if isinstance(filesets_info, list):
-        for idx, fileset_info in enumerate(filesets_info):
+        for fileset_info in filesets_info:
             try:
                 fileset, _needs_update = _load_fileset(scan, fileset_info)
             except Exception as e:

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -41,15 +41,13 @@ A comprehensive module for managing file system operations in a hierarchical dat
 """
 
 import json
-
 import pathlib
 from shutil import rmtree
 
 from tqdm import tqdm
 
-from .exceptions import FileNoIDError
-from .exceptions import FilesetNoIDError
-from .exceptions import FilesetNotFoundError
+from plant3dvision.utils import yes_no_choice
+from .exceptions import FileNotFoundError
 from .metadata import _load_file_metadata
 from .metadata import _load_fileset_metadata
 from .metadata import _load_metadata
@@ -66,10 +64,10 @@ from .serialization import _parse_file
 from .serialization import _parse_fileset
 from .serialization import _scan_to_dict
 from .validation import _is_safe_to_delete
-
 from ..log import get_logger
 
 logger = get_logger(__name__)
+
 
 def _load_scan(db, scan_id):
     """Load ``Scan`` from given database.
@@ -131,7 +129,9 @@ def _load_scan(db, scan_id):
         #  - path to scan directory exists
         #  - required subdirectories exists, if any
         #  - required files exists, if any
-        scan.filesets = _load_scan_filesets(scan)
+        scan.filesets, needs_update = _load_scan_filesets(scan)
+        if needs_update:
+            _store_scan(scan)
         scan.metadata = _load_scan_metadata(scan)
         scan.measures = _load_scan_measures(scan)
     else:
@@ -179,6 +179,8 @@ def _load_scans(db):
     >>> print(scans)
     [<plantdb.commons.fsdb.core.Scan object at 0x7fa01220bd50>]
     """
+    from plantdb.commons.fsdb.core import Scan
+
     # List all subdirectories of the database path:
     dir_names = db.path().iterdir()
     # Filter out non-directories:
@@ -189,6 +191,7 @@ def _load_scans(db):
 
     # Loop through the directories and load them as scan if they meet the criteria
     scans = {}
+    bad_scans = set()
     for dir_name in tqdm(dir_names, unit="scan"):
         scan_name = dir_name.name  # get the scan name from the directory
         if scan_name.startswith('.'):
@@ -198,6 +201,17 @@ def _load_scans(db):
         # If the scan could be loaded, add it to the dictionary of scans
         if scan is not None:
             scans[scan_name] = scan
+        else:
+            bad_scans.add(scan_name)
+
+    if bad_scans:
+        n_bad = len(bad_scans)
+        logger.info(f"Found {n_bad} bad scans: {', '.join(bad_scans)}")
+        if yes_no_choice(
+                f"Do you want to remove th{'is' if n_bad == 1 else 'ese'} {len(bad_scans)} scan{'' if n_bad == 1 else 's'}?"):
+            for scan_name in bad_scans:
+                _delete_scan(Scan(db, scan_name))
+
     return scans
 
 
@@ -303,26 +317,27 @@ def _load_scan_filesets(scan):
     # Load it:
     with files_json.open(mode="r") as f:
         structure = json.load(f)
+
+    # Inform `_load_scan` to update the `files.json` associated with the `scan`
+    needs_update = False
+
     # Get the list of info (dict) about the filesets
     filesets_info = structure["filesets"]
     if isinstance(filesets_info, list):
-        for n, fileset_info in enumerate(filesets_info):
+        for idx, fileset_info in enumerate(filesets_info):
             try:
-                fileset = _load_fileset(scan, fileset_info)
-                fsid = fileset_info.get("id")
-                if fsid is None:
-                    raise FilesetNoIDError(f"Missing 'id' for the {n}-th 'filesets' entry.")
-                filesets[fsid] = fileset
-            except FilesetNoIDError:
-                logger.error(f"Could not get an 'id' entry for the {n}-th 'filesets' entry from '{scan.id}'.")
-                logger.debug(f"Current `fileset_info`: {fileset_info}")
-            except FilesetNotFoundError:
-                fsid = fileset_info.get("id", None)
-                logger.error(f"Fileset directory '{fsid}' not found for scan {scan.id}, skip it.")
+                fileset, _needs_update = _load_fileset(scan, fileset_info)
+            except Exception as e:
+                logger.error(e)
+                needs_update = True
+            else:
+                needs_update = needs_update or _needs_update
+                filesets[fileset.id] = fileset
     else:
-        raise IOError(f"Could not find a list of filesets in '{files_json}'.")
+        logger.error(f"Could not load a list of filesets for scan '{scan.id}' from: '{files_json}'")
+        return None, True
 
-    return filesets
+    return filesets, needs_update
 
 
 def _load_fileset(scan, fileset_info):
@@ -337,7 +352,7 @@ def _load_fileset(scan, fileset_info):
 
     Returns
     -------
-    plantdb.commons.fsdb.core.Fileset
+    plantdb.commons.fsdb.core.Fileset | None
         A fileset with its ``files`` & ``metadata`` attributes restored.
 
     Examples
@@ -360,9 +375,9 @@ def _load_fileset(scan, fileset_info):
     ['dummy_image', 'test_image', 'test_json']
     """
     fileset = _parse_fileset(scan, fileset_info)
-    fileset.files = _load_fileset_files(fileset, fileset_info)
+    fileset.files, needs_update = _load_fileset_files(fileset, fileset_info)
     fileset.metadata = _load_fileset_metadata(fileset)
-    return fileset
+    return fileset, needs_update
 
 
 def _load_fileset_files(fileset, fileset_info):
@@ -407,27 +422,25 @@ def _load_fileset_files(fileset, fileset_info):
     >>> print([f.id for f in files])
     ['dummy_image', 'test_image', 'test_json']
     """
-    scan_id = fileset.scan.id
     files = {}
     files_info = fileset_info.get("files", None)
+
+    # Inform `_load_fileset` to update the `files.json` associated with the `scan`
+    needs_update = False
+
     if isinstance(files_info, list):
-        for n, file_info in enumerate(files_info):
+        for idx, file_info in enumerate(files_info):
             try:
                 file = _load_file(fileset, file_info)
-            except FileNoIDError:
-                logger.error(f"Could not get an 'id' entry for the {n}-th 'files' entry from '{scan_id}'.")
-                logger.debug(f"Current `file_info`: {file_info}")
-            except FileNotFoundError:
-                fs_id = fileset.id
-                fname = file_info.get("file")
-                logger.error(f"Could not find file '{fname}' for '{scan_id}/{fs_id}'.")
-                logger.debug(f"Current `file_info`: {file_info}")
+            except Exception as e:
+                logger.error(e)
+                needs_update = True
             else:
-                fid = file_info.get("id")
-                files[fid] = file
+                files[file.id] = file
     else:
         raise IOError(f"Expected a list of files in `files.json` from dataset '{fileset.scan.id}'!")
-    return files
+
+    return files, needs_update
 
 
 def _load_file(fileset, file_info):

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -46,7 +46,6 @@ from shutil import rmtree
 
 from tqdm import tqdm
 
-from plant3dvision.utils import yes_no_choice
 from .exceptions import FileNotFoundError
 from .metadata import _load_file_metadata
 from .metadata import _load_fileset_metadata

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -64,6 +64,7 @@ from .serialization import _parse_fileset
 from .serialization import _scan_to_dict
 from .validation import _is_safe_to_delete
 from ..log import get_logger
+from ..utils import yes_no_choice
 
 logger = get_logger(__name__)
 

--- a/src/commons/plantdb/commons/fsdb/lock.py
+++ b/src/commons/plantdb/commons/fsdb/lock.py
@@ -325,12 +325,35 @@ class ScanLockManager :
         acquired = False
         start_time = time.time()
 
+        # Helper to check for conflicting active locks of a different type
+        def _has_active_lock(other_type: LockType) -> bool:
+            other_key = f"{scan_id}_{other_type.value}"
+            return other_key in self._active_locks
+
         try:
             lock_file_path = self._get_lock_file_path(scan_id)
 
             attempt = 0
             while time.time() - start_time < timeout:
                 attempt += 1
+
+                # Respect intra‑process lock conflicts before touching the file
+                if lock_type == LockType.SHARED and _has_active_lock(LockType.EXCLUSIVE):
+                    # An exclusive lock is active → treat as unavailable and retry
+                    self.logger.debug(
+                        f"Shared lock request for scan {scan_id} blocked by active exclusive lock"
+                    )
+                    time.sleep(0.5)
+                    continue
+
+                if lock_type == LockType.EXCLUSIVE and _has_active_lock(LockType.SHARED):
+                    # One or more shared locks are active → wait
+                    self.logger.debug(
+                        f"Exclusive lock request for scan {scan_id} blocked by active shared lock(s)"
+                    )
+                    time.sleep(0.5)
+                    continue
+
                 try:
                     # Open lock file
                     lock_fd = os.open(lock_file_path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC)

--- a/src/commons/plantdb/commons/fsdb/lock.py
+++ b/src/commons/plantdb/commons/fsdb/lock.py
@@ -584,12 +584,14 @@ class LockManager:
         # Look for locks matching this resource and level
         for lock_key, lock_info in self._active_locks.items():
             # Extract resource_id and level from the lock key
-            # Format: resource_id_level_locktype
-            parts = lock_key.split('/', 2)
-            if len(parts) != 3:
+            # Format: resource_id/lock_level/lock_type
+            parts = lock_key.split('/')
+            if len(parts) < 3:
                 continue
-                
-            lock_resource_id, lock_level, _ = parts
+
+            lock_type = parts.pop(-1)
+            lock_level = parts.pop(-1)
+            lock_resource_id = "/".join(parts)
             # Check if this lock belongs to the requested resource and level
             if lock_resource_id == resource_id and lock_level == level.value:
                 if lock_info['type'] == LockType.EXCLUSIVE:

--- a/src/commons/plantdb/commons/fsdb/lock.py
+++ b/src/commons/plantdb/commons/fsdb/lock.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 """
-# ScanLockManager
+# LockManager
 
 File-based locking for thread-safe resource management
 
-The `ScanLockManager` module provides a robust file-based locking mechanism to ensure thread-safe operations across multiple threads or processes.
-It allows acquiring and releasing locks on resources identified by scan IDs, with support for both shared (read) and exclusive (write) locks.
+The `LockManager` module provides a robust file-based locking mechanism to ensure thread-safe operations across multiple threads or processes.
+It allows acquiring and releasing locks on resources identified by scan, fileset, or file IDs, with support for both shared (read) and exclusive (write) locks.
 
 ## Key Features
 
@@ -16,22 +16,27 @@ It allows acquiring and releasing locks on resources identified by scan IDs, wit
 - Lock timeout to prevent indefinite waiting for lock acquisition
 - Automatic cleanup of stale locks on initialization
 - Monitoring and debugging capabilities with lock metadata storage
+- Support for multiple lock levels: Scan, Fileset, and File
 
 ## Usage Examples
 
 ```python
-from plantdb.commons.fsdb.lock import ScanLockManager
+from plantdb.commons.fsdb.lock import LockManager, LockType
 
 # Initialize the lock manager with a base path
-manager = ScanLockManager('/path/to/database')
+manager = LockManager('/path/to/database')
 
-# Acquire an exclusive lock for 'scan123'
-with manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1'):
+# Acquire an exclusive lock for a scan
+with manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1', level='scan'):
     # Perform critical section operations...
 
-# Check the status of locks for 'scan123'
-status = manager.get_lock_status('scan123')
-print(status)
+# Acquire a shared lock for a fileset
+with manager.acquire_lock('scan123/fileset1', LockType.SHARED, user='user1', level='fileset'):
+    # Perform critical section operations...
+
+# Acquire an exclusive lock for a file
+with manager.acquire_lock('scan123/fileset1/file1', LockType.EXCLUSIVE, user='user1', level='file'):
+    # Perform critical section operations...
 ```
 """
 
@@ -48,8 +53,15 @@ from typing import Optional
 from plantdb.commons.log import get_logger
 
 
+class LockLevel(Enum):
+    """Enumeration of lock levels supported by the LockManager."""
+    SCAN = "scan"          # Lock at scan level
+    FILESET = "fileset"    # Lock at fileset level  
+    FILE = "file"          # Lock at file level
+
+
 class LockType(Enum):
-    SHARED = "shared"  # Read operations
+    SHARED = "shared"      # Read operations
     EXCLUSIVE = "exclusive"  # Write operations
 
 
@@ -75,7 +87,7 @@ class LockTimeoutError(Exception):
         return self.message
 
 
-class ScanLockManager :
+class LockManager:
     """Acquires and releases file-based locks for thread-safe resource management.
 
     This class provides functionality for acquiring and releasing file-based locks,
@@ -97,12 +109,12 @@ class ScanLockManager :
     locks_dir: str
         Location of the directory where lock files are stored.
     _active_locks : Dict[str, Dict]
-        Dictionary mapping lock names (scan ID + lock type) to dictionaries containing information about the lock including:
+        Dictionary mapping lock names to dictionaries containing information about the lock including:
 
            - 'type': the type of the lock (shared or exclusive),
            - 'user': the user who acquired the lock (if available),
            - 'timestamp': the timestamp when the lock was acquired (if available),
-           - 'count': int indicating how many locks are active for a given scan and lock type combination,
+           - 'count': int indicating how many locks are active for a given resource and lock type combination,
     _lock_files : Dict[str, int]
         The file descriptors (int) for each active lock in the dictionary mapping.
     _thread_lock: threading.RLock
@@ -110,9 +122,9 @@ class ScanLockManager :
 
     Examples
     --------
-    >>> from plantdb.commons.fsdb.lock import ScanLockManager
-    >>> manager = ScanLockManager('/path/to/local/database')
-    >>> lock = manager.acquire_lock('scan123')
+    >>> from plantdb.commons.fsdb.lock import LockManager
+    >>> manager = LockManager('/path/to/local/database')
+    >>> lock = manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1', level='scan')
     """
 
     def __init__(self, base_path: str, default_timeout: float = 30.0, **kwargs):
@@ -139,7 +151,7 @@ class ScanLockManager :
         self._lock_files: Dict[str, int] = {}  # File descriptors for locks
         self._thread_lock = threading.RLock()  # Thread-safe operations
 
-        # Store the last time we emitted a warning per scan_id
+        # Store the last time we emitted a warning per resource
         self._warning_timestamps: Dict[str, float] = {}
         # How long we wait before emitting the same warning again (seconds)
         self._warning_debounce_interval: float = kwargs.get("warning_debounce_interval", 5.0)
@@ -152,7 +164,7 @@ class ScanLockManager :
             os.remove(test_file)
         except PermissionError as e:
             # Create a logger without the log_file as it will not be writable either
-            logger = get_logger(__name__ + '.ScanLockManager', log_level="DEBUG")
+            logger = get_logger(__name__ + '.LockManager', log_level="DEBUG")
             logger.error(f"Cannot write to base_path `{base_path}`.")
             logger.debug(f"Current UID={os.getuid()}, GID={os.getgid()}")
             raise e
@@ -160,45 +172,84 @@ class ScanLockManager :
         # Ensure locks directory exists
         os.makedirs(self.locks_dir, exist_ok=True)
         # Initialize lock manager logger
-        self.logger = get_logger(__name__ + '.ScanLockManager',
+        self.logger = get_logger(__name__ + '.LockManager',
                                  log_file=kwargs.get("log_file", os.path.join(base_path, '.locks', 'lock_manager.log')),
                                  log_level=kwargs.get("log_level", "INFO"))
-        self.logger.debug(f"Initialized ScanLockManager with base path: `{base_path}`")
+        self.logger.debug(f"Initialized LockManager with base path: `{base_path}`")
         # Clean up stale locks on initialization
         self._cleanup_stale_locks()
 
-    def _get_lock_file_path(self, scan_id: str) -> str:
+    def _get_lock_file_path(self, resource_id: str, level: LockLevel) -> str:
         """
-        Generates the file path for a lock file based on the provided scan ID.
+        Generates the file path for a lock file based on the provided resource ID and level.
 
         Parameters
         ----------
-        scan_id : str
-            The unique identifier for the scan.
+        resource_id : str
+            The unique identifier for the resource (scan_id, scan_id/fileset_id, or scan_id/fileset_id/file_id).
+        level : LockLevel
+            The level of the lock (scan, fileset, or file).
 
         Returns
         -------
         str
             The full path to the lock file.
         """
-        # Use a single lock file per scan_id
-        return os.path.join(self.locks_dir, f"{scan_id}.lock")
+        # For scan level, use scan_id.lock
+        # For fileset level, use scan_id_fileset_id.lock  
+        # For file level, use scan_id_fileset_id_file_id.lock
+        
+        if level == LockLevel.SCAN:
+            return os.path.join(self.locks_dir, f"{resource_id}.lock")
+        elif level == LockLevel.FILESET:
+            # Split the resource_id to extract scan_id and fileset_id
+            parts = resource_id.split('/')
+            scan_id = parts[0]
+            fileset_id = parts[1]
+            return os.path.join(self.locks_dir, f"{scan_id}_{fileset_id}.lock")
+        else:  # FILE level
+            # Split the resource_id to extract scan_id, fileset_id, and file_id
+            parts = resource_id.split('/')
+            scan_id = parts[0]
+            fileset_id = parts[1]
+            file_id = parts[2]
+            return os.path.join(self.locks_dir, f"{scan_id}_{fileset_id}_{file_id}.lock")
 
-    def _get_lock_info_path(self, scan_id: str) -> str:
+    def _get_lock_info_path(self, resource_id: str, level: LockLevel) -> str:
         """
-        Get the path to the lock info file for a given scan ID.
+        Get the path to the lock info file for a given resource ID and level.
 
         Parameters
         ----------
-        scan_id : str
-            The identifier of the scan.
+        resource_id : str
+            The identifier of the resource.
+        level : LockLevel
+            The level of the lock (scan, fileset, or file).
 
         Returns
         -------
         str
             The absolute path to the lock info file.
         """
-        return os.path.join(self.locks_dir, f"{scan_id}.info")
+        # For scan level, use scan_id.info
+        # For fileset level, use scan_id_fileset_id.info  
+        # For file level, use scan_id_fileset_id_file_id.info
+        
+        if level == LockLevel.SCAN:
+            return os.path.join(self.locks_dir, f"{resource_id}.info")
+        elif level == LockLevel.FILESET:
+            # Split the resource_id to extract scan_id and fileset_id
+            parts = resource_id.split('/')
+            scan_id = parts[0]
+            fileset_id = parts[1]
+            return os.path.join(self.locks_dir, f"{scan_id}_{fileset_id}.info")
+        else:  # FILE level
+            # Split the resource_id to extract scan_id, fileset_id, and file_id
+            parts = resource_id.split('/')
+            scan_id = parts[0]
+            fileset_id = parts[1]
+            file_id = parts[2]
+            return os.path.join(self.locks_dir, f"{scan_id}_{fileset_id}_{file_id}.info")
 
     def _cleanup_stale_locks(self):
         """Remove stale lock files from previous sessions"""
@@ -226,10 +277,11 @@ class ScanLockManager :
         self.logger.info(f"Cleaned up {cleaned_count} stale lock files")
         return
 
-    def _write_lock_info(self, scan_id: str, lock_type: LockType, user: str):
+    def _write_lock_info(self, resource_id: str, lock_type: LockType, user: str, level: LockLevel):
         """Write lock metadata for monitoring and debugging"""
         info = {
-            'scan_id': scan_id,
+            'resource_id': resource_id,
+            'level': level.value,
             'lock_type': lock_type.value,
             'user': user,
             'timestamp': time.time(),
@@ -237,35 +289,37 @@ class ScanLockManager :
             'thread_id': threading.get_ident()
         }
 
-        info_path = self._get_lock_info_path(scan_id)
+        info_path = self._get_lock_info_path(resource_id, level)
         with open(info_path, 'w') as f:
             json.dump(info, f, indent=2)
 
-    def _remove_lock_info(self, scan_id: str):
+    def _remove_lock_info(self, resource_id: str, level: LockLevel):
         """Remove lock metadata file"""
-        info_path = self._get_lock_info_path(scan_id)
+        info_path = self._get_lock_info_path(resource_id, level)
         try:
             os.unlink(info_path)
         except OSError:
             pass
 
     @contextmanager
-    def acquire_lock(self, scan_id: str, lock_type: LockType, user: str, timeout: Optional[float] = None):
+    def acquire_lock(self, resource_id: str, lock_type: LockType, user: str, level: LockLevel, timeout: Optional[float] = None):
         """
-        Acquire a lock for a specific scan and lock type.
+        Acquire a lock for a specific resource and lock type.
 
-        This method attempts to acquire a lock (either shared or exclusive) for a given scan ID.
+        This method attempts to acquire a lock (either shared or exclusive) for a given resource ID.
         If the lock is successfully acquired, it yields control to the calling code.
         Upon completion of the calling code, it ensures that the lock is released.
 
         Parameters
         ----------
-        scan_id : str
-            The unique identifier for the scan.
+        resource_id : str
+            The unique identifier for the resource (scan_id, scan_id/fileset_id, or scan_id/fileset_id/file_id).
         lock_type : LockType
             The type of lock to acquire (shared or exclusive).
         user : str
             The user requesting the lock.
+        level : LockLevel
+            The level of the lock (scan, fileset, or file).
         timeout : Optional[float], optional
             The maximum time to wait for acquiring the lock, in seconds. If not provided,
             uses a default timeout value.
@@ -287,9 +341,10 @@ class ScanLockManager :
         lock is already held.
         """
         timeout = timeout or self.default_timeout
-        lock_key = f"{scan_id}_{lock_type.value}"
+        # Create a unique lock key based on resource_id, level, and lock type
+        lock_key = f"{resource_id}/{level.value}/{lock_type.value}"
 
-        self.logger.debug(f"Attempting to acquire {lock_type.value} lock for scan {scan_id} by user {user}")
+        self.logger.debug(f"Attempting to acquire {lock_type.value} lock for {level.value} {resource_id} by user {user}")
 
         with self._thread_lock:
             # Check if we already have this lock
@@ -297,29 +352,29 @@ class ScanLockManager :
                 # For shared locks, allow multiple acquisitions
                 if lock_type == LockType.SHARED:
                     self._active_locks[lock_key]['count'] += 1
-                    self.logger.debug(f"Incrementing shared lock count for {scan_id}")
+                    self.logger.debug(f"Incrementing shared lock count for {level.value} {resource_id}")
                     try:
                         yield
                         return
                     finally:
                         self._active_locks[lock_key]['count'] -= 1
                         if self._active_locks[lock_key]['count'] <= 0:
-                            self._release_lock(scan_id, lock_type)
+                            self._release_lock(resource_id, lock_type, level)
                 else:
                     # For exclusive locks, allow reentrant acquisition by the same user/thread
                     current_lock_user = self._active_locks[lock_key].get('user')
                     if current_lock_user == user:
                         self._active_locks[lock_key]['count'] += 1
-                        self.logger.debug(f"Incrementing exclusive lock count for {scan_id} by same user {user}")
+                        self.logger.debug(f"Incrementing exclusive lock count for {level.value} {resource_id} by same user {user}")
                         try:
                             yield
                             return
                         finally:
                             self._active_locks[lock_key]['count'] -= 1
                             if self._active_locks[lock_key]['count'] <= 0:
-                                self._release_lock(scan_id, lock_type)
+                                self._release_lock(resource_id, lock_type, level)
                     else:
-                        raise LockError(f"Exclusive lock already held for scan {scan_id}")
+                        raise LockError(f"Exclusive lock already held for {level.value} {resource_id}")
 
         # Acquire new lock
         acquired = False
@@ -327,11 +382,11 @@ class ScanLockManager :
 
         # Helper to check for conflicting active locks of a different type
         def _has_active_lock(other_type: LockType) -> bool:
-            other_key = f"{scan_id}_{other_type.value}"
+            other_key = f"{resource_id}/{level.value}/{other_type.value}"
             return other_key in self._active_locks
 
         try:
-            lock_file_path = self._get_lock_file_path(scan_id)
+            lock_file_path = self._get_lock_file_path(resource_id, level)
 
             attempt = 0
             while time.time() - start_time < timeout:
@@ -341,7 +396,7 @@ class ScanLockManager :
                 if lock_type == LockType.SHARED and _has_active_lock(LockType.EXCLUSIVE):
                     # An exclusive lock is active → treat as unavailable and retry
                     self.logger.debug(
-                        f"Shared lock request for scan {scan_id} blocked by active exclusive lock"
+                        f"Shared lock request for {level.value} {resource_id} blocked by active exclusive lock"
                     )
                     time.sleep(0.5)
                     continue
@@ -349,7 +404,7 @@ class ScanLockManager :
                 if lock_type == LockType.EXCLUSIVE and _has_active_lock(LockType.SHARED):
                     # One or more shared locks are active → wait
                     self.logger.debug(
-                        f"Exclusive lock request for scan {scan_id} blocked by active shared lock(s)"
+                        f"Exclusive lock request for {level.value} {resource_id} blocked by active shared lock(s)"
                     )
                     time.sleep(0.5)
                     continue
@@ -366,8 +421,8 @@ class ScanLockManager :
 
                     # Try to acquire the lock (non-blocking)
                     fcntl.flock(lock_fd, lock_flags)
-                    # SUCCESS - clear any stale warning timestamp for this scan_id
-                    self._warning_timestamps.pop(scan_id, None)
+                    # SUCCESS - clear any stale warning timestamp for this resource
+                    self._warning_timestamps.pop(resource_id, None)
 
                     # Lock acquired successfully
                     with self._thread_lock:
@@ -379,10 +434,10 @@ class ScanLockManager :
                         }
                         self._lock_files[lock_key] = lock_fd
 
-                    self._write_lock_info(scan_id, lock_type, user)
+                    self._write_lock_info(resource_id, lock_type, user, level)
                     acquired = True
                     self.logger.debug(
-                        f"Successfully acquired {lock_type.value} lock for scan {scan_id} "
+                        f"Successfully acquired {lock_type.value} lock for {level.value} {resource_id} "
                         f"(attempt {attempt})"
                     )
                     break
@@ -395,23 +450,23 @@ class ScanLockManager :
                         pass
 
                     now = time.time()
-                    last_warn = self._warning_timestamps.get(scan_id, 0.0)
+                    last_warn = self._warning_timestamps.get(resource_id, 0.0)
                     if now - last_warn >= self._warning_debounce_interval:
                         self.logger.warning(
-                            f"Lock acquisition attempt failed for {scan_id} (attempt {attempt}) - "
+                            f"Lock acquisition attempt failed for {level.value} {resource_id} (attempt {attempt}) - "
                             f"retrying... [pid={os.getpid()}, tid={threading.get_ident()}]"
                         )
-                        self._warning_timestamps[scan_id] = now
+                        self._warning_timestamps[resource_id] = now
                     else:
                         # We’re within the debounce window - log at DEBUG instead of spamming WARN
                         self.logger.debug(
-                            f"Retrying lock for {scan_id} (attempt {attempt}) - still waiting"
+                            f"Retrying lock for {level.value} {resource_id} (attempt {attempt}) - still waiting"
                         )
                     time.sleep(0.1)  # Brief pause before retry
 
             if not acquired:
                 raise LockTimeoutError(
-                    f"Could not acquire {lock_type.value} lock for scan {scan_id} within {timeout} seconds")
+                    f"Could not acquire {lock_type.value} lock for {level.value} {resource_id} within {timeout} seconds")
 
             # Yield control to the calling code
             yield
@@ -419,11 +474,11 @@ class ScanLockManager :
         finally:
             # Always release the lock
             if acquired:
-                self._release_lock(scan_id, lock_type)
+                self._release_lock(resource_id, lock_type, level)
 
-    def _release_lock(self, scan_id: str, lock_type: LockType):
+    def _release_lock(self, resource_id: str, lock_type: LockType, level: LockLevel):
         """
-        Release a lock for a given scan ID and lock type.
+        Release a lock for a given resource ID and lock type.
 
         This method releases an existing lock by unlocking the file descriptor, closing it,
         and removing the associated files and information from internal data structures.
@@ -431,15 +486,17 @@ class ScanLockManager :
 
         Parameters
         ----------
-        scan_id : str
-            The unique identifier of the scan whose lock needs to be released.
+        resource_id : str
+            The unique identifier of the resource whose lock needs to be released.
         lock_type : LockType
             The type of lock to release.
+        level : LockLevel
+            The level of the lock (scan, fileset, or file).
 
         Notes
         -----
         This method should only be called after a successful acquisition of the same lock
-        type for the given scan ID. It uses internal thread locks and file operations to ensure
+        type for the given resource ID. It uses internal thread locks and file operations to ensure
         atomicity and consistency of lock management.
 
         See Also
@@ -452,8 +509,8 @@ class ScanLockManager :
         This method modifies internal data structures and should be used with caution.
         Improper use might lead to inconsistencies in the lock state or lost locks.
         """
-        lock_key = f"{scan_id}_{lock_type.value}"
-        self.logger.debug(f"Releasing {lock_type.value} lock for scan {scan_id}")
+        lock_key = f"{resource_id}/{level.value}/{lock_type.value}"
+        self.logger.debug(f"Releasing {lock_type.value} lock for {level.value} {resource_id}")
 
         with self._thread_lock:
             if lock_key in self._active_locks:
@@ -463,39 +520,41 @@ class ScanLockManager :
                         fd = self._lock_files[lock_key]
                         fcntl.flock(fd, fcntl.LOCK_UN)
                         os.close(fd)
-                        self.logger.debug(f"Closed file descriptor for {scan_id}")
+                        self.logger.debug(f"Closed file descriptor for {resource_id}")
                     except Exception as e:
-                        self.logger.error(f"Error closing lock file for {scan_id}: {str(e)}")
+                        self.logger.error(f"Error closing lock file for {resource_id}: {str(e)}")
                     del self._lock_files[lock_key]
 
                 # Remove from active locks
                 del self._active_locks[lock_key]
 
                 # Clean up lock file
-                lock_file_path = self._get_lock_file_path(scan_id)
+                lock_file_path = self._get_lock_file_path(resource_id, level)
                 try:
                     os.unlink(lock_file_path)
-                    self.logger.debug(f"Removed lock file for {scan_id}")
+                    self.logger.debug(f"Removed lock file for {resource_id}")
                 except OSError as e:
-                    self.logger.error(f"Error removing lock file for {scan_id}: {str(e)}")
+                    self.logger.error(f"Error removing lock file for {resource_id}: {str(e)}")
 
                 # Remove lock info
-                self._remove_lock_info(scan_id)
-                self.logger.debug(f"Successfully released lock for scan {scan_id}")
+                self._remove_lock_info(resource_id, level)
+                self.logger.debug(f"Successfully released lock for {level.value} {resource_id}")
 
-    def get_lock_status(self, scan_id: str) -> Dict:
+    def get_lock_status(self, resource_id: str, level: LockLevel) -> Dict:
         """
-        Retrieve the current lock status for a given scan ID.
+        Retrieve the current lock status for a given resource ID.
 
         This method checks all active locks and determines if there is an
-        exclusive or shared lock associated with the specified scan ID. It returns
+        exclusive or shared lock associated with the specified resource. It returns
         a dictionary containing information about the exclusive lock (if any) and
-        all shared locks associated with the scan ID.
+        all shared locks associated with the resource.
 
         Parameters
         ----------
-        scan_id : str
-            The unique identifier of the scan for which to retrieve the lock status.
+        resource_id : str
+            The unique identifier of the resource for which to retrieve the lock status.
+        level : LockLevel
+            The level of the lock (scan, fileset, or file).
 
         Returns
         -------
@@ -508,22 +567,31 @@ class ScanLockManager :
 
         Notes
         -----
-        This method iterates through all active locks to find matches with the given scan ID.
+        This method iterates through all active locks to find matches with the given resource ID.
         It distinguishes between exclusive and shared locks based on their type.
 
         Examples
         --------
-        >>> from plantdb.commons.fsdb.lock import ScanLockManager
-        >>> manager = ScanLockManager('/path/to/local/database')
-        >>> lock = manager.acquire_lock('scan123')
-        >>> status = manager.get_lock_status("scan123")
+        >>> from plantdb.commons.fsdb.lock import LockManager
+        >>> manager = LockManager('/path/to/local/database')
+        >>> lock = manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1', level='scan')
+        >>> status = manager.get_lock_status("scan123", LockLevel.SCAN)
         >>> print(status)
         {'exclusive': None, 'shared': [{'user': 'user1', 'timestamp': '2023-01-01T12:00:00', 'count': 1}]}
         """
         status = {'exclusive': None, 'shared': []}
 
+        # Look for locks matching this resource and level
         for lock_key, lock_info in self._active_locks.items():
-            if lock_key.startswith(scan_id):
+            # Extract resource_id and level from the lock key
+            # Format: resource_id_level_locktype
+            parts = lock_key.split('/', 2)
+            if len(parts) != 3:
+                continue
+                
+            lock_resource_id, lock_level, _ = parts
+            # Check if this lock belongs to the requested resource and level
+            if lock_resource_id == resource_id and lock_level == level.value:
                 if lock_info['type'] == LockType.EXCLUSIVE:
                     status['exclusive'] = {
                         'user': lock_info['user'],
@@ -543,7 +611,13 @@ class ScanLockManager :
         self.logger.warning("Cleaning up all active locks...")
         with self._thread_lock:
             for lock_key in list(self._active_locks.keys()):
-                scan_id, lock_type_str = lock_key.split('_', 1)
+                # Parse the lock key to extract resource_id and level
+                parts = lock_key.split('/', 2)
+                if len(parts) != 3:
+                    continue
+                    
+                resource_id, level_str, lock_type_str = parts
+                level = LockLevel(level_str)
                 lock_type = LockType(lock_type_str)
-                self._release_lock(scan_id, lock_type)
+                self._release_lock(resource_id, lock_type, level)
         return

--- a/src/commons/plantdb/commons/fsdb/lock.py
+++ b/src/commons/plantdb/commons/fsdb/lock.py
@@ -339,6 +339,20 @@ class LockManager:
         This method uses a context manager and should be used within a 'with' statement. It handles both shared
         and exclusive locks, allowing multiple acquisitions for shared locks but raising an exception if an exclusive
         lock is already held.
+
+        Examples
+        --------
+        >>> import tempfile
+        >>> from plantdb.commons.fsdb.lock import LockManager
+        >>> from plantdb.commons.fsdb.lock import LockType
+        >>> from plantdb.commons.fsdb.lock import LockLevel
+        >>> manager = LockManager(tempfile.gettempdir())
+        >>> with manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1', level=LockLevel.SCAN):
+        ...     print("scan123/scan/exclusive" in manager._active_locks)
+        True
+        >>> with manager.acquire_lock('scan123/test_fileset', LockType.EXCLUSIVE, user='user1', level=LockLevel.FILESET):
+        ...     print("scan123/test_fileset/fileset/exclusive" in manager._active_locks)
+        True
         """
         timeout = timeout or self.default_timeout
         # Create a unique lock key based on resource_id, level, and lock type
@@ -572,12 +586,19 @@ class LockManager:
 
         Examples
         --------
+        >>> import tempfile
         >>> from plantdb.commons.fsdb.lock import LockManager
-        >>> manager = LockManager('/path/to/local/database')
-        >>> lock = manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1', level='scan')
-        >>> status = manager.get_lock_status("scan123", LockLevel.SCAN)
-        >>> print(status)
-        {'exclusive': None, 'shared': [{'user': 'user1', 'timestamp': '2023-01-01T12:00:00', 'count': 1}]}
+        >>> from plantdb.commons.fsdb.lock import LockType
+        >>> from plantdb.commons.fsdb.lock import LockLevel
+        >>> manager = LockManager(tempfile.gettempdir())
+        >>> with manager.acquire_lock('scan123', LockType.EXCLUSIVE, user='user1', level=LockLevel.SCAN):
+        ...     status = manager.get_lock_status("scan123", LockLevel.SCAN)
+        ...     print(status)
+        {'exclusive': {'user': 'user1', 'timestamp': 1775734565.6584513}, 'shared': []}
+        >>> with manager.acquire_lock('scan123/test_fileset', LockType.EXCLUSIVE, user='user1', level=LockLevel.FILESET):
+        ...     status = manager.get_lock_status("scan123/test_fileset", LockLevel.FILESET)
+        ...     print(status)
+        {'exclusive': {'user': 'user1', 'timestamp': 1775734690.2060757}, 'shared': []}
         """
         status = {'exclusive': None, 'shared': []}
 

--- a/src/commons/plantdb/commons/fsdb/metadata.py
+++ b/src/commons/plantdb/commons/fsdb/metadata.py
@@ -354,7 +354,7 @@ class MetadataManager(object):
             return
 
         # Acquire exclusive lock on the *scan* – this mirrors the original behaviour.
-        self.logger.info(
+        self.logger.debug(
             f"Updating '{self.id}' {cls_name.lower()} metadata as '{current_user.username}' user..."
         )
         if isinstance(self, Scan):
@@ -366,5 +366,5 @@ class MetadataManager(object):
             _set_metadata(self.metadata, new_metadata, None)
             self._store_and_timestamp(store_func)
 
-        self.logger.info(f"Done updating the {cls_name.lower()} metadata.")
+        self.logger.debug(f"Done updating the {cls_name.lower()} metadata.")
         return

--- a/src/commons/plantdb/commons/fsdb/metadata.py
+++ b/src/commons/plantdb/commons/fsdb/metadata.py
@@ -50,6 +50,8 @@ from typing import MutableMapping
 from typing import Union
 from typing import TYPE_CHECKING
 
+from .lock import LockLevel
+
 # ----------------------------------------------------------------------
 # NOTE: The following imports are only needed for type‑checking / IDE hints.
 # Importing them at runtime creates a circular dependency with `core.py`.
@@ -347,22 +349,33 @@ class MetadataManager(object):
     def _update_metadata(self, data, value, current_user, store_func, cls_name):
         """High‑level driver used by the concrete classes."""
         from plantdb.commons.fsdb.core import Scan
+        from plantdb.commons.fsdb.core import Fileset
+        from plantdb.commons.fsdb.core import File
 
         new_metadata = self._prepare_new_metadata(data, value)
         self._scrub_forbidden_keys(new_metadata, cls_name)
         if len(new_metadata) == 0:
             return
 
-        # Acquire exclusive lock on the *scan* – this mirrors the original behaviour.
-        self.logger.debug(
-            f"Updating '{self.id}' {cls_name.lower()} metadata as '{current_user.username}' user..."
-        )
         if isinstance(self, Scan):
-            obj = self
+            obj_id = f"{self.id}"
+            lock_level = LockLevel.SCAN
+        elif isinstance(self, Fileset):
+            obj_id = f"{self.scan.id}/{self.id}"
+            lock_level = LockLevel.FILESET
+        elif isinstance(self, File):
+            obj_id = f"{self.scan.id}/{self.fileset.id}/{self.id}"
+            lock_level = LockLevel.FILE
         else:
-            obj = self.scan
+            raise TypeError(
+                f"Unsupported object type for metadata update: {type(self).__name__}"
+            )
 
-        with self.db.lock_manager.acquire_lock(obj.id, LockType.EXCLUSIVE, current_user.username):
+        # Acquire exclusive lock on the object
+        self.logger.debug(
+            f"Updating '{obj_id}' {cls_name.lower()} metadata as '{current_user.username}' user..."
+        )        
+        with self.db.lock_manager.acquire_lock(obj_id, LockType.EXCLUSIVE, current_user.username, lock_level):
             _set_metadata(self.metadata, new_metadata, None)
             self._store_and_timestamp(store_func)
 

--- a/src/commons/plantdb/commons/fsdb/serialization.py
+++ b/src/commons/plantdb/commons/fsdb/serialization.py
@@ -50,13 +50,13 @@ file = _parse_file(fileset, file_info)
 ```
 """
 
-from .path_helpers import _file_path
-from .path_helpers import _fileset_path
 from .exceptions import FileNoFileNameError
 from .exceptions import FileNoIDError
 from .exceptions import FileNotFoundError
 from .exceptions import FilesetNoIDError
 from .exceptions import FilesetNotFoundError
+from .path_helpers import _file_path
+from .path_helpers import _fileset_path
 from ..log import get_logger
 
 logger = get_logger(__name__)
@@ -79,7 +79,7 @@ def _parse_fileset(scan, fileset_info):
     from plantdb.commons.fsdb.core import Fileset
     fsid = fileset_info.get("id", None)
     if fsid is None:
-        raise FilesetNoIDError("Fileset: No ID")
+        raise FilesetNoIDError(scan)
 
     fileset = Fileset(scan, fsid)
     # Get the expected directory path and check it exists:
@@ -118,7 +118,7 @@ def _parse_file(fileset, file_info):
     fid = file_info.get("id", None)
     if fid is None:
         logger.debug(f"Input `file_info`: {file_info}")
-        raise FileNoIDError(f"File: No ID for file '{file_info}'")
+        raise FileNoIDError(fileset)
 
     filename = file_info.get("file", None)
     if filename is None:

--- a/src/commons/plantdb/commons/fsdb/serialization.py
+++ b/src/commons/plantdb/commons/fsdb/serialization.py
@@ -131,7 +131,7 @@ def _parse_file(fileset, file_info):
     path = _file_path(file)
     if not path.is_file():
         logger.debug(f"Missing file: {path}")
-        raise FileNotFoundError(f"File: Not found at '{path}'")
+        raise FileNotFoundError(fileset, fid)
     return file
 
 

--- a/src/commons/plantdb/commons/io.py
+++ b/src/commons/plantdb/commons/io.py
@@ -500,7 +500,6 @@ def _write_volume(fname, data, **kwargs):
         The data object to save.
     """
     import imageio.v3 as iio
-    import tifffile
     try:
         import imagecodecs
     except ImportError:
@@ -512,17 +511,9 @@ def _write_volume(fname, data, **kwargs):
 
     fname = Path(fname)
     ext = fname.suffix  # get the extension
-    # Override extension if specified in keyword-argument:
+    # Override extension if specified in the keyword-argument:
     kwargs['extension'] = ext
-    if kwargs.get('compress', False):
-        # By default, use LZW compression with `tifffile.imwrite`:
-        if 'compression' not in kwargs:
-            kwargs['compression'] = 'LZW'
-        tifffile.imwrite(fname, data, **kwargs)
-    else:
-        kwargs.pop('compress', None)
-        # No compression with `imageio.v3`
-        iio.imwrite(fname, data, **kwargs)
+    iio.imwrite(fname, data, **kwargs)
     return
 
 
@@ -538,32 +529,25 @@ def write_volume(file, data, ext="tiff", **kwargs):
     ext : str, optional
         File extension, defaults to "tiff".
 
-    Other Parameters
-    ----------------
-    compress : bool, optional
-        Indicate if the volume file should be compressed.
-        Defaults to ``True``.
-
     Examples
     --------
     >>> import numpy as np
-    >>> from plantdb.commons.fsdb.core import FSDB
     >>> from plantdb.commons.io import write_volume
-    >>> from plantdb.commons.fsdb.core import Scan, Fileset, File
     >>> from plantdb.commons.test_database import dummy_db
     >>> db = dummy_db(with_fileset=True)
     >>> db.connect()
     >>> scan = db.get_scan("myscan_001")
     >>> fs = scan.get_fileset("fileset_001")
-    >>> vol = np.ones((50, 10, 10))  # stupid volume file with only `1` values
-    >>> f_lzw = fs.create_file('test_volume_compress')
-    >>> write_volume(f_lzw, vol)
-    >>> f = fs.create_file('test_volume')
-    >>> write_volume(f, vol, compress=False)
-    >>> print(f_lzw.path().stat().st_size)
-    15283
-    >>> print(f.path().stat().st_size)
-    48994
+    >>> vol = np.random.randint(0, 254, (10, 10, 10), 'uint8')  # random volume file with 8bit values
+    >>> f_uint8 = fs.create_file('test_volume_uint8')
+    >>> write_volume(f_uint8, vol)
+    >>> f_uint16 = fs.create_file('test_volume_uint16')
+    >>> write_volume(f_uint16, vol.astype('uint16'))
+    >>> print(f_uint8.path().stat().st_size)
+    2750
+    >>> print(f_uint16.path().stat().st_size)
+    3750
+    >>> db.disconnect()
     """
     _writer(file, data, ext, _write_volume, **kwargs)
     return

--- a/src/commons/plantdb/commons/io.py
+++ b/src/commons/plantdb/commons/io.py
@@ -102,8 +102,7 @@ Trained tensor, read and written using ``torch``.
 import tempfile
 from pathlib import Path
 
-from plantdb.commons import db
-from plantdb.commons import fsdb
+from plantdb.commons.db import File
 from plantdb.commons.log import get_logger
 
 logger = get_logger(__name__)
@@ -114,7 +113,7 @@ def _reader(file, reader, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
     reader : function
         The function to use to read the data.
@@ -125,7 +124,7 @@ def _reader(file, reader, **kwargs):
         The loaded data.
     """
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the file with the selected reader:
     with open(file, 'r') as f:
@@ -138,7 +137,7 @@ def _write_db_file(dbfile, data, ext, writer, **kwargs):
 
     Parameters
     ----------
-    dbfile : plantdb.commons.db.File
+    dbfile : plantdb.commons.File
         The ``File`` instance to save the data to.
     data : Any
         The data to save.
@@ -160,7 +159,7 @@ def _writer(file, data, ext, writer, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the point cloud data to the given file path, ignoring the extension parameter `ext`.
     data : Any
@@ -170,7 +169,7 @@ def _writer(file, data, ext, writer, **kwargs):
     writer : function
         The function to use to write the `data`.
     """
-    if isinstance(file, db.File):
+    if isinstance(file, File):
         _write_db_file(file, data, ext, writer, **kwargs)
     else:
         writer(file, data, **kwargs)
@@ -182,7 +181,7 @@ def read_json(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -207,7 +206,7 @@ def read_json(file, **kwargs):
     """
     import json
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the file:
     with open(file, mode='r') as f:
@@ -238,7 +237,7 @@ def write_json(file, data, ext="json", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : dict
@@ -267,7 +266,7 @@ def read_toml(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -292,7 +291,7 @@ def read_toml(file, **kwargs):
     """
     import toml
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the file:
     with open(file, mode='r') as f:
@@ -321,7 +320,7 @@ def write_toml(file, data, ext="toml", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : dict
@@ -350,7 +349,7 @@ def read_image(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -377,7 +376,7 @@ def read_image(file, **kwargs):
     """
     import imageio.v3 as iio
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return iio.imread(file, **kwargs)
 
@@ -424,7 +423,7 @@ def write_image(file, data, ext="png", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : array like
@@ -455,7 +454,7 @@ def read_volume(file, ext="tiff", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
     ext : str, optional
         File extension, defaults to "tiff".
@@ -484,7 +483,7 @@ def read_volume(file, ext="tiff", **kwargs):
     """
     import imageio.v3 as iio
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return iio.imread(file, **kwargs)
 
@@ -522,7 +521,7 @@ def write_volume(file, data, ext="tiff", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File
+    file : plantdb.commons.File
         The `File` object used to write the associated file.
     data : array like
         The 3D array to save as volume image.
@@ -558,7 +557,7 @@ def read_npz(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -585,7 +584,7 @@ def read_npz(file, **kwargs):
     """
     import numpy as np
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return dict(np.load(file, **kwargs))
 
@@ -610,7 +609,7 @@ def write_npz(file, data, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : dict of numpy.ndarray
@@ -639,7 +638,7 @@ def read_point_cloud(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -670,7 +669,7 @@ def read_point_cloud(file, **kwargs):
     """
     from open3d import io
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return io.read_point_cloud(str(file), **kwargs)
 
@@ -695,7 +694,7 @@ def write_point_cloud(file, data, ext="ply", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : open3d.geometry.PointCloud
@@ -727,7 +726,7 @@ def read_triangle_mesh(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -737,7 +736,7 @@ def read_triangle_mesh(file, **kwargs):
     """
     from open3d import io
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return io.read_triangle_mesh(str(file), **kwargs)
 
@@ -762,7 +761,7 @@ def write_triangle_mesh(file, data, ext="ply", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : open3d.geometry.TriangleMesh
@@ -779,7 +778,7 @@ def read_voxel_grid(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -789,7 +788,7 @@ def read_voxel_grid(file, **kwargs):
     """
     from open3d import io
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return io.read_voxel_grid(str(file), **kwargs)
 
@@ -814,7 +813,7 @@ def write_voxel_grid(file, data, ext="ply", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File
+    file : plantdb.commons.File
         The `File` object used to write the associated file.
     data : open3d.geometry.VoxelGrid
         The voxel grid object to save.
@@ -835,7 +834,7 @@ def read_graph(file, **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
 
     Returns
@@ -864,7 +863,7 @@ def read_graph(file, **kwargs):
     """
     import pickle
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     # Load the pickled file:
     with open(file, mode='rb') as f:
@@ -897,7 +896,7 @@ def write_graph(file, data, ext="p", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : networkx.Graph
@@ -927,7 +926,7 @@ def read_torch(file, ext="pt", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         A ``File`` instance or file path, to read from.
     ext : str, optional
         File extension, defaults to "pt".
@@ -950,7 +949,7 @@ def read_torch(file, ext="pt", **kwargs):
     """
     import torch
     # Get path to file if in a database:
-    if isinstance(file, fsdb.core.File):
+    if isinstance(file, File):
         file = file.path()
     return torch.load(file, **kwargs)
 
@@ -975,7 +974,7 @@ def write_torch(file, data, ext="pt", **kwargs):
 
     Parameters
     ----------
-    file : plantdb.commons.db.File or pathlib.Path or str
+    file : plantdb.commons.File or pathlib.Path or str
         If a ``File`` instance, the file will be saved to the associated database/scan/fileset.
         Else, write the `data` to the given file path, ignoring the extension parameter `ext`.
     data : TorchTensor

--- a/src/commons/plantdb/commons/test_database.py
+++ b/src/commons/plantdb/commons/test_database.py
@@ -67,12 +67,11 @@ from tempfile import mkdtemp
 from zipfile import ZipFile
 
 import requests
+from tqdm import tqdm
 
 from plantdb.commons.auth.session import NoAuthSessionManager
 from plantdb.commons.auth.session import SessionManager
-from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.log import get_logger
-from tqdm import tqdm
 
 DATASET = ["real_plant", "real_plant_analyzed",
            "virtual_plant", "virtual_plant_analyzed",
@@ -234,7 +233,7 @@ def _test_hash(tmp_fname, hash_value, hash_method="md5"):
     return
 
 
-def _get_archive(archive, force=False) :
+def _get_archive(archive, force=False) -> Path:
     """Download and verify an archive file from a given URL.
 
     This function retrieves an archive file from a specified URL.
@@ -251,7 +250,7 @@ def _get_archive(archive, force=False) :
 
     Returns
     -------
-    Path
+    pathlib.Path
         The path to the downloaded and verified archive file.
     """
     url = ZIP_URLS[archive]
@@ -265,7 +264,7 @@ def _get_archive(archive, force=False) :
     return tmp_fname
 
 
-def _get_extract_archive(archive, out_path=TEST_DIR, keep_tmp=False, force=False):
+def _get_extract_archive(archive, out_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract an archive from ZENODO.
 
     Parameters
@@ -302,7 +301,7 @@ def _get_extract_archive(archive, out_path=TEST_DIR, keep_tmp=False, force=False
     return out_path / archive
 
 
-def get_test_dataset(dataset, db_path=TEST_DIR, keep_tmp=False, force=False):
+def get_test_dataset(dataset, db_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract a test dataset from ZENODO.
 
     Parameters
@@ -334,7 +333,7 @@ def get_test_dataset(dataset, db_path=TEST_DIR, keep_tmp=False, force=False):
     return db_path
 
 
-def get_models_dataset(db_path=TEST_DIR, keep_tmp=False, force=False):
+def get_models_dataset(db_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract the trained CNN model from ZENODO.
 
     Parameters
@@ -364,7 +363,7 @@ def get_models_dataset(db_path=TEST_DIR, keep_tmp=False, force=False):
     return db_path
 
 
-def get_configs(db_path=TEST_DIR, keep_tmp=False, force=False):
+def get_configs(db_path=TEST_DIR, keep_tmp=False, force=False) -> Path:
     """Download and extract the pipeline configurations from ZENODO.
 
     Parameters
@@ -394,7 +393,7 @@ def get_configs(db_path=TEST_DIR, keep_tmp=False, force=False):
     return db_path
 
 
-def setup_empty_database(db_path=None):
+def setup_empty_database(db_path=None) -> Path:
     """Sets up an empty ROMI database.
 
     Sets up necessary marker file and ensures the absence of a lock file.
@@ -443,7 +442,8 @@ def setup_empty_database(db_path=None):
     return db_path
 
 
-def setup_test_database(dataset, db_path=TEST_DIR, keep_tmp=True, with_configs=False, with_models=False, force=False):
+def setup_test_database(dataset, db_path=TEST_DIR,
+                        keep_tmp=True, with_configs=False, with_models=False, force=False) -> Path:
     """Download and extract the test database from ZENODO.
 
     Parameters
@@ -570,21 +570,22 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     >>> db.disconnect()
     """
     from plantdb.commons.fsdb.core import FSDB
-    # Use the 'no_auth' keyword argument to define the correct session manager
-    if kwargs.pop('no_auth', False):
-        session_manager = NoAuthSessionManager()
-    else:
-        session_manager = SingleSessionManager()
+    # Extract the 'no_auth' keyword argument to pass it to FSDB.__init__
+    no_auth = kwargs.pop('no_auth', False)
     # If a valid session manager is provided as input, use it
     in_manager = kwargs.pop('session_manager', None)
-    if in_manager and isinstance(in_manager, SessionManager):
+    if isinstance(in_manager, SessionManager):
         session_manager = in_manager
+    else:
+        session_manager = None
 
     # Create the test database with selected dataset and session manager
     if dataset is None:
-        return FSDB(setup_empty_database(db_path=db_path), session_manager=session_manager)
+        return FSDB(setup_empty_database(db_path=db_path),
+                    session_manager=session_manager, no_auth=no_auth)
     else:
-        return FSDB(setup_test_database(dataset, db_path=db_path, **kwargs), session_manager=session_manager)
+        return FSDB(setup_test_database(dataset, db_path=db_path, **kwargs),
+                    session_manager=session_manager, no_auth=no_auth)
 
 
 def dummy_db(with_scan=False, with_fileset=False, with_file=False):

--- a/src/commons/plantdb/commons/test_database.py
+++ b/src/commons/plantdb/commons/test_database.py
@@ -67,6 +67,8 @@ from tempfile import mkdtemp
 from zipfile import ZipFile
 
 import requests
+
+from plantdb.commons.auth.session import NoAuthSessionManager
 from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.log import get_logger
 from tqdm import tqdm
@@ -513,7 +515,7 @@ def setup_test_database(dataset, db_path=TEST_DIR, keep_tmp=True, with_configs=F
     db.connect()
     db.list_scans(owner_only=False)
     for scan_name, scan in db.scans.items():
-        _ = scan.owner  # get the owner of the scan, if unknown, it will be set to the anonymous user
+        _ = scan.owner  # get the owner of the scan, if unknown, it will be set to the 'guest' user
     db.disconnect()
 
     logger.info(f"The test database is set up under '{db_path}'.")
@@ -535,6 +537,8 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
 
     Other Parameters
     ----------------
+    session_manager : SessionManager
+        The session manager to use, defaults to ``NoAuthSessionManager``.
     keep_tmp : bool
         Whether to keep the temporary files. Defaults to ``False``.
     with_configs : bool
@@ -554,14 +558,14 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     >>> from plantdb.commons.test_database import test_database
     >>> db = test_database()
     >>> db.connect()
-    >>> db.list_scans()
+    >>> db.list_scans(owner_only=False)
     ['real_plant_analyzed']
     >>> db.path()
     PosixPath('/tmp/ROMI_DB_********')
     >>> db.disconnect()
     """
     from plantdb.commons.fsdb.core import FSDB
-    session_manager = kwargs.pop('session_manager', None)
+    session_manager = kwargs.pop('session_manager', NoAuthSessionManager())
     if dataset is None:
         return FSDB(setup_empty_database(db_path=db_path), session_manager=session_manager)
     else:
@@ -599,10 +603,9 @@ def dummy_db(with_scan=False, with_fileset=False, with_file=False):
     --------
     >>> from plantdb.commons.test_database import dummy_db
     >>> db = dummy_db(with_file=True)
-    >>> db.connect()
     INFO     [FSDB] Connected to database successfully
     >>> from plantdb.commons.fsdb.core import get_logged_username
-    >>> get_logged_username(db)  # 'admin' is logged by default
+    >>> get_logged_username(db).username  # 'admin' is logged by default
     'admin'
     >>> print(db.path())  # the database directory
     /tmp/romidb_********
@@ -631,12 +634,10 @@ def dummy_db(with_scan=False, with_fileset=False, with_file=False):
     marker_file = db_path / MARKER_FILE_NAME
     marker_file.open(mode='w').close()
     # Create the FSDB instance and connect
-    db = FSDB(db_path, required_filesets=[], session_manager=SingleSessionManager())
+    db = FSDB(db_path, required_filesets=[], session_manager=NoAuthSessionManager())
     # Flag this instance as a dummy DB so that disconnect will clean up the temp folder
     db._is_dummy = True
     db.connect()
-    # Login as adin to get all the rights (to create and edit)
-    _ = db.login('admin', 'admin')
 
     if with_file:
         # To create a `File`, existing `Scan` & `Fileset` are required

--- a/src/commons/plantdb/commons/test_database.py
+++ b/src/commons/plantdb/commons/test_database.py
@@ -69,6 +69,7 @@ from zipfile import ZipFile
 import requests
 
 from plantdb.commons.auth.session import NoAuthSessionManager
+from plantdb.commons.auth.session import SessionManager
 from plantdb.commons.auth.session import SingleSessionManager
 from plantdb.commons.log import get_logger
 from tqdm import tqdm
@@ -537,8 +538,12 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
 
     Other Parameters
     ----------------
+    no_auth : bool
+        A boolean flag to switch between session managers.
+        If ``True``, use `NoAuthSessionManager` else use `SingleSessionManager`.
     session_manager : SessionManager
         The session manager to use, defaults to ``NoAuthSessionManager``.
+        Override the `no_auth` parameter.
     keep_tmp : bool
         Whether to keep the temporary files. Defaults to ``False``.
     with_configs : bool
@@ -556,7 +561,7 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     Examples
     --------
     >>> from plantdb.commons.test_database import test_database
-    >>> db = test_database()
+    >>> db = test_database(no_auth=True)
     >>> db.connect()
     >>> db.list_scans(owner_only=False)
     ['real_plant_analyzed']
@@ -565,7 +570,17 @@ def test_database(dataset='real_plant_analyzed', db_path=None, **kwargs):
     >>> db.disconnect()
     """
     from plantdb.commons.fsdb.core import FSDB
-    session_manager = kwargs.pop('session_manager', NoAuthSessionManager())
+    # Use the 'no_auth' keyword argument to define the correct session manager
+    if kwargs.pop('no_auth', False):
+        session_manager = NoAuthSessionManager()
+    else:
+        session_manager = SingleSessionManager()
+    # If a valid session manager is provided as input, use it
+    in_manager = kwargs.pop('session_manager', None)
+    if in_manager and isinstance(in_manager, SessionManager):
+        session_manager = in_manager
+
+    # Create the test database with selected dataset and session manager
     if dataset is None:
         return FSDB(setup_empty_database(db_path=db_path), session_manager=session_manager)
     else:

--- a/src/commons/plantdb/commons/utils.py
+++ b/src/commons/plantdb/commons/utils.py
@@ -304,15 +304,15 @@ def yes_no_choice(question: str, default: bool=True) -> bool:
     --------
     >>> from plantdb.commons.utils import yes_no_choice
     >>> yes_no_choice("Is ROMI an awesome project?")
-    Is ROMI an awesome project? [YES/no]>?
-    Out[3]: True
+    Is ROMI an awesome project? [Y/n]>?
+    True
     >>> yes_no_choice("I am your father!", default=False)
-    I am your father! [yes/NO]>?
-    Out[5]: False
+    I am your father! [y/N]>?
+    False
     """
     opt = {"": default, "yes": True, "y": True, "ye": True, "no": False, "n": False}
-    default_str = "YES" if default else "NO"
-    prompt = f"{question} [{default_str}/{'no' if default else 'yes'}]>"
+    default_choice = " [Y/n]" if default else " [y/N]"
+    prompt = f"{question} {default_choice}"
     while True:
         kbd = input(prompt).strip().lower()
         # Empty input -> take the supplied default

--- a/src/commons/plantdb/commons/utils.py
+++ b/src/commons/plantdb/commons/utils.py
@@ -304,10 +304,10 @@ def yes_no_choice(question: str, default: bool=True) -> bool:
     --------
     >>> from plantdb.commons.utils import yes_no_choice
     >>> yes_no_choice("Is ROMI an awesome project?")
-    Is ROMI an awesome project? [Y/n]>?
+    Is ROMI an awesome project? [Y/n]>
     True
     >>> yes_no_choice("I am your father!", default=False)
-    I am your father! [y/N]>?
+    I am your father! [y/N]>
     False
     """
     opt = {"": default, "yes": True, "y": True, "ye": True, "no": False, "n": False}

--- a/src/commons/plantdb/commons/utils.py
+++ b/src/commons/plantdb/commons/utils.py
@@ -289,3 +289,35 @@ def iso_date_now():
     '2025-09-16T23:39:54.132898'
     """
     return datetime.isoformat(datetime.now())
+
+def yes_no_choice(question: str, default: bool=True) -> bool:
+    """Raise a yes/no question with a default reply and wait for a valid reply from user.
+
+    Parameters
+    ----------
+    question : str
+        The question to ask.
+    default : bool, optional
+        The default answer to the question.
+
+    Examples
+    --------
+    >>> from plantdb.commons.utils import yes_no_choice
+    >>> yes_no_choice("Is ROMI an awesome project?")
+    Is ROMI an awesome project? [YES/no]>?
+    Out[3]: True
+    >>> yes_no_choice("I am your father!", default=False)
+    I am your father! [yes/NO]>?
+    Out[5]: False
+    """
+    opt = {"": default, "yes": True, "y": True, "ye": True, "no": False, "n": False}
+    default_str = "YES" if default else "NO"
+    prompt = f"{question} [{default_str}/{'no' if default else 'yes'}]>"
+    while True:
+        kbd = input(prompt).strip().lower()
+        # Empty input -> take the supplied default
+        if kbd == "":
+            return default
+        if kbd in opt:
+            return opt[kbd]
+        print("Please answer with 'yes' or 'no'.")

--- a/src/commons/pyproject.toml
+++ b/src/commons/pyproject.toml
@@ -76,7 +76,6 @@ doc = [
 ]
 io = [
     "networkx",
-    "tifffile",
     "open3d >=0.9.0.0",
 ]
 test = [

--- a/src/commons/pyproject.toml
+++ b/src/commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plantdb.commons"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
     "appdirs",
     "argon2-cffi",

--- a/src/commons/tests/test_auth.py
+++ b/src/commons/tests/test_auth.py
@@ -149,6 +149,41 @@ class TestUserManager(unittest.TestCase):
         is_valid = self.user_manager.validate_user_password("testuser", "wrong_password")
         self.assertFalse(is_valid)
 
+    def test_update_password_success_case(self):
+        """Test successful password update scenario."""
+        # Update password
+        self.user_manager.update_password("testuser", "testpassword", "newpassword")
+        
+        # Verify the password was updated by validating the new password
+        is_valid = self.user_manager.validate_user_password("testuser", "newpassword")
+        self.assertTrue(is_valid)
+        
+        # Verify old password is no longer valid
+        is_valid_old = self.user_manager.validate_user_password("testuser", "testpassword")
+        self.assertFalse(is_valid_old)
+
+    def test_update_password_invalid_current_password(self):
+        """Test password update fails when current password is incorrect."""
+        # Try to update password with wrong current password
+        self.user_manager.update_password("testuser", "wrongpassword", "newpassword")
+        
+        # Verify the password was NOT updated by validating the old password still works
+        is_valid_old = self.user_manager.validate_user_password("testuser", "testpassword")
+        self.assertTrue(is_valid_old)
+        
+        # Verify new password is not valid
+        is_valid_new = self.user_manager.validate_user_password("testuser", "newpassword")
+        self.assertFalse(is_valid_new)
+
+    def test_update_password_nonexistent_user(self):
+        """Test password update fails for nonexistent user."""
+        # Try to update password for non-existent user
+        self.user_manager.update_password("nonexistent", "testpassword", "newpassword")
+        
+        # Verify the password was NOT updated by validating the old password still works
+        is_valid_old = self.user_manager.validate_user_password("testuser", "testpassword")
+        self.assertTrue(is_valid_old)
+
 
 class TestGroupManager(unittest.TestCase):
     """Test cases for GroupManager class"""

--- a/src/commons/tests/test_fsdb_lock.py
+++ b/src/commons/tests/test_fsdb_lock.py
@@ -459,6 +459,100 @@ class TestConcurrentLocks(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(len(errors), 4)  # The other 4 should have timed out
 
+    def test_exclusive_lock_blocks_shared_lock(self):
+        """Verify that an exclusive lock prevents acquiring a shared lock for the same scan_id."""
+        scan_id = "test_scan"
+        user1 = "user1"
+        user2 = "user2"
+        results = []
+        errors = []
+
+        def acquire_exclusive_lock():
+            try:
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1, timeout=60.):
+                    # Hold the exclusive lock for a while
+                    time.sleep(0.5)
+                    # Try to acquire a shared lock (this should not happen while exclusive holds)
+                    results.append("exclusive_held")
+            except Exception as e:
+                errors.append(str(e))
+
+        def acquire_shared_lock():
+            try:
+                # Try to acquire a shared lock while exclusive is held
+                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, timeout=0.5):
+                    results.append("shared_acquired")
+            except Exception as e:
+                errors.append(str(e))
+
+        # Start exclusive lock thread
+        exclusive_thread = threading.Thread(target=acquire_exclusive_lock)
+        exclusive_thread.start()
+
+        # Give exclusive thread time to acquire the lock
+        time.sleep(0.1)
+
+        # Start shared lock thread
+        shared_thread = threading.Thread(target=acquire_shared_lock)
+        shared_thread.start()
+
+        # Wait for both threads to complete
+        exclusive_thread.join()
+        shared_thread.join()
+
+        # Verify that exclusive lock was acquired and shared lock failed
+        # The exclusive lock should be acquired and held, then released
+        # The shared lock should fail to acquire due to the exclusive lock
+        self.assertIn("exclusive_held", results)
+        self.assertEqual(len(errors), 1)  # Should have one error from shared lock attempt
+
+    def test_shared_lock_blocks_exclusive_lock(self):
+        """Verify that a shared lock prevents acquiring an exclusive lock for the same scan_id."""
+        scan_id = "test_scan"
+        user1 = "user1"
+        user2 = "user2"
+        results = []
+        errors = []
+
+        def acquire_shared_lock():
+            try:
+                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1):
+                    # Hold the shared lock for a while
+                    time.sleep(0.5)
+                    results.append("shared_held")
+            except Exception as e:
+                errors.append(str(e))
+
+        def acquire_exclusive_lock():
+            try:
+                # Try to acquire an exclusive lock while shared is held
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, timeout=0.5):
+                    results.append("exclusive_acquired")
+            except Exception as e:
+                errors.append(str(e))
+
+        # Start shared lock thread
+        shared_thread = threading.Thread(target=acquire_shared_lock)
+        shared_thread.start()
+
+        # Give shared thread time to acquire the lock
+        time.sleep(0.1)
+
+        # Start exclusive lock thread
+        exclusive_thread = threading.Thread(target=acquire_exclusive_lock)
+        exclusive_thread.start()
+
+        # Wait for both threads to complete
+        shared_thread.join()
+        exclusive_thread.join()
+
+        # The test should verify that the exclusive lock attempt times out
+        # Since we're using a short timeout, we expect the exclusive lock acquisition to fail
+        # This confirms that shared locks block exclusive locks
+        self.assertIn("shared_held", results)
+        # At least one error should be present from the exclusive lock attempt
+        self.assertGreater(len(errors), 0)
+
 
 class TestFSDBLock(unittest.TestCase):
     """Test suite for verifying permission handling in FSDB operations.

--- a/src/commons/tests/test_fsdb_lock.py
+++ b/src/commons/tests/test_fsdb_lock.py
@@ -83,21 +83,45 @@ class TestLockManager(unittest.TestCase):
     def test_get_lock_file_path(self):
         """Verify that _get_lock_file_path returns the correct path."""
         scan_id = "test_scan"
-        # Test for shared lock
+        # Test for SCAN level
         expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}.lock")
         actual_path = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
         self.assertEqual(actual_path, expected_path)
 
-        # Test for exclusive lock
-        expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}.lock")
-        actual_path = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
+        # Test for FILESET level
+        fileset_id = "test_fileset"
+        resource_id = f"{scan_id}/{fileset_id}"
+        expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}_{fileset_id}.lock")
+        actual_path = self.lock_manager._get_lock_file_path(resource_id, LockLevel.FILESET)
+        self.assertEqual(actual_path, expected_path)
+
+        # Test for FILE level
+        file_id = "test_file"
+        resource_id = f"{scan_id}/{fileset_id}/{file_id}"
+        expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}_{fileset_id}_{file_id}.lock")
+        actual_path = self.lock_manager._get_lock_file_path(resource_id, LockLevel.FILE)
         self.assertEqual(actual_path, expected_path)
 
     def test_get_lock_info_path(self):
         """Verify that _get_lock_info_path returns the correct path."""
         scan_id = "test_scan"
+        # Test for SCAN level
         expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}.info")
         actual_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
+        self.assertEqual(actual_path, expected_path)
+
+        # Test for FILESET level
+        fileset_id = "test_fileset"
+        resource_id = f"{scan_id}/{fileset_id}"
+        expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}_{fileset_id}.info")
+        actual_path = self.lock_manager._get_lock_info_path(resource_id, LockLevel.FILESET)
+        self.assertEqual(actual_path, expected_path)
+
+        # Test for FILE level
+        file_id = "test_file"
+        resource_id = f"{scan_id}/{fileset_id}/{file_id}"
+        expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}_{fileset_id}_{file_id}.info")
+        actual_path = self.lock_manager._get_lock_info_path(resource_id, LockLevel.FILE)
         self.assertEqual(actual_path, expected_path)
 
     @patch('fcntl.flock')
@@ -130,6 +154,23 @@ class TestLockManager(unittest.TestCase):
         # Verify that unlink was called for each lock file
         self.assertEqual(mock_unlink.call_count, 2)
 
+    def test_cleanup_stale_locks_with_active_locks(self):
+        """Verify that _cleanup_stale_locks preserves active lock files."""
+        # Create a lock file that will be considered active (by not mocking flock)
+        locks_dir = os.path.join(self.temp_dir, ".locks")
+        lock_file = os.path.join(locks_dir, "active_scan.lock")
+        
+        # Create the lock file
+        with open(lock_file, 'w') as f:
+            f.write("")
+
+        # Make sure the file exists
+        self.assertTrue(os.path.exists(lock_file))
+
+        # Call the cleanup method
+        self.lock_manager._cleanup_stale_locks()
+        self.assertFalse(os.path.exists(lock_file))
+
     def test_write_and_remove_lock_info(self):
         """Verify that _write_lock_info creates a lock info file and _remove_lock_info removes it."""
         scan_id = "test_scan"
@@ -155,6 +196,69 @@ class TestLockManager(unittest.TestCase):
 
         # Remove lock info
         self.lock_manager._remove_lock_info(scan_id, LockLevel.SCAN)
+
+        # Check that the file no longer exists
+        self.assertFalse(os.path.exists(info_path))
+
+    def test_write_lock_info_fileset_level(self):
+        """Verify that _write_lock_info works with fileset level locks."""
+        scan_id = "test_scan"
+        fileset_id = "test_fileset"
+        resource_id = f"{scan_id}/{fileset_id}"
+        lock_type = LockType.SHARED
+        user = "test_user"
+
+        # Write lock info
+        self.lock_manager._write_lock_info(resource_id, lock_type, user, LockLevel.FILESET)
+
+        # Check that the file exists
+        info_path = self.lock_manager._get_lock_info_path(resource_id, LockLevel.FILESET)
+        self.assertTrue(os.path.exists(info_path))
+
+        # Verify the content of the file
+        with open(info_path, 'r') as f:
+            info = json.load(f)
+            self.assertEqual(info['resource_id'], resource_id)
+            self.assertEqual(info['lock_type'], lock_type.value)
+            self.assertEqual(info['user'], user)
+            self.assertIn('timestamp', info)
+            self.assertIn('pid', info)
+            self.assertIn('thread_id', info)
+
+        # Remove lock info
+        self.lock_manager._remove_lock_info(resource_id, LockLevel.FILESET)
+
+        # Check that the file no longer exists
+        self.assertFalse(os.path.exists(info_path))
+
+    def test_write_lock_info_file_level(self):
+        """Verify that _write_lock_info works with file level locks."""
+        scan_id = "test_scan"
+        fileset_id = "test_fileset"
+        file_id = "test_file"
+        resource_id = f"{scan_id}/{fileset_id}/{file_id}"
+        lock_type = LockType.EXCLUSIVE
+        user = "test_user"
+
+        # Write lock info
+        self.lock_manager._write_lock_info(resource_id, lock_type, user, LockLevel.FILE)
+
+        # Check that the file exists
+        info_path = self.lock_manager._get_lock_info_path(resource_id, LockLevel.FILE)
+        self.assertTrue(os.path.exists(info_path))
+
+        # Verify the content of the file
+        with open(info_path, 'r') as f:
+            info = json.load(f)
+            self.assertEqual(info['resource_id'], resource_id)
+            self.assertEqual(info['lock_type'], lock_type.value)
+            self.assertEqual(info['user'], user)
+            self.assertIn('timestamp', info)
+            self.assertIn('pid', info)
+            self.assertIn('thread_id', info)
+
+        # Remove lock info
+        self.lock_manager._remove_lock_info(resource_id, LockLevel.FILE)
 
         # Check that the file no longer exists
         self.assertFalse(os.path.exists(info_path))
@@ -352,6 +456,63 @@ class TestLockManager(unittest.TestCase):
                 self.assertIn('user', status['shared'][0])
                 self.assertIn('timestamp', status['shared'][0])
                 self.assertEqual(status['shared'][0]['count'], 2)
+
+    def test_get_lock_status_complex_combinations(self):
+        """Verify that get_lock_status works correctly with complex lock combinations."""
+        scan_id = "test_scan"
+        user1 = "user1"
+        user2 = "user2"
+
+        # Acquire an exclusive lock
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1, LockLevel.SCAN):
+            # Get the lock status - should show exclusive lock
+            status = self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
+            self.assertIsNotNone(status['exclusive'])
+            self.assertEqual(status['exclusive']['user'], user1)
+            self.assertEqual(status['shared'], [])
+
+            # Acquire a shared lock for the same resource (this should block)
+            # But we'll test this differently by checking the internal state directly
+            # since we're already holding an exclusive lock
+            
+            # Get the lock status after acquiring exclusive lock
+            status = self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
+            self.assertIsNotNone(status['exclusive'])
+            self.assertEqual(status['exclusive']['user'], user1)
+            self.assertEqual(status['shared'], [])
+
+        # After releasing all locks, status should be empty
+        status = self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
+        self.assertEqual(status, {'exclusive': None, 'shared': []})
+
+    def test_get_lock_status_fileset_level(self):
+        """Verify that get_lock_status works with fileset level locks."""
+        scan_id = "test_scan"
+        fileset_id = "test_fileset"
+        resource_id = f"{scan_id}/{fileset_id}"
+        user1 = "user1"
+        user2 = "user2"
+
+        # Acquire an exclusive lock at fileset level
+        with self.lock_manager.acquire_lock(resource_id, LockType.EXCLUSIVE, user1, LockLevel.FILESET):
+            # Get the lock status
+            status = self.lock_manager.get_lock_status(resource_id, LockLevel.FILESET)
+            
+            # Check the status
+            self.assertIsNotNone(status['exclusive'])
+            self.assertEqual(status['exclusive']['user'], user1)
+            self.assertEqual(status['shared'], [])
+
+        # Acquire a shared lock at fileset level
+        with self.lock_manager.acquire_lock(resource_id, LockType.SHARED, user2, LockLevel.FILESET):
+            # Get the lock status
+            status = self.lock_manager.get_lock_status(resource_id, LockLevel.FILESET)
+            
+            # Check the status
+            self.assertIsNone(status['exclusive'])
+            self.assertEqual(len(status['shared']), 1)
+            self.assertEqual(status['shared'][0]['user'], user2)
+            self.assertEqual(status['shared'][0]['count'], 1)
 
     def test_cleanup_all_locks(self):
         """Verify that cleanup_all_locks releases all active locks."""
@@ -554,6 +715,65 @@ class TestConcurrentLocks(unittest.TestCase):
         self.assertIn("shared_held", results)
         # At least one error should be present from the exclusive lock attempt
         self.assertGreater(len(errors), 0)
+
+    def test_file_level_locks(self):
+        """Verify that file level locks work correctly."""
+        scan_id = "test_scan"
+        fileset_id = "test_fileset"
+        file_id = "test_file"
+        resource_id = f"{scan_id}/{fileset_id}/{file_id}"
+        user1 = "user1"
+        user2 = "user2"
+
+        # Acquire an exclusive lock at file level
+        with self.lock_manager.acquire_lock(resource_id, LockType.EXCLUSIVE, user1, LockLevel.FILE):
+            # Check that the lock file exists
+            lock_file = self.lock_manager._get_lock_file_path(resource_id, LockLevel.FILE)
+            self.assertTrue(os.path.exists(lock_file))
+
+            # Check that the lock is registered in active locks
+            lock_key = f"{resource_id}/file/exclusive"
+            self.assertIn(lock_key, self.lock_manager._active_locks)
+            self.assertEqual(self.lock_manager._active_locks[lock_key]['type'], LockType.EXCLUSIVE)
+            self.assertEqual(self.lock_manager._active_locks[lock_key]['user'], user1)
+            self.assertEqual(self.lock_manager._active_locks[lock_key]['count'], 1)
+
+            # Check that the lock info file exists
+            info_path = self.lock_manager._get_lock_info_path(resource_id, LockLevel.FILE)
+            self.assertTrue(os.path.exists(info_path))
+
+        # After the context manager exits, check that the lock is released
+        lock_file = self.lock_manager._get_lock_file_path(resource_id, LockLevel.FILE)
+        self.assertFalse(os.path.exists(lock_file))
+        lock_key = f"{resource_id}/file/exclusive"
+        self.assertNotIn(lock_key, self.lock_manager._active_locks)
+        info_path = self.lock_manager._get_lock_info_path(resource_id, LockLevel.FILE)
+        self.assertFalse(os.path.exists(info_path))
+
+    def test_multiple_file_level_locks(self):
+        """Verify that multiple file level locks can be acquired for different files."""
+        scan_id = "test_scan"
+        fileset_id = "test_fileset"
+        file_id1 = "test_file1"
+        file_id2 = "test_file2"
+        resource_id1 = f"{scan_id}/{fileset_id}/{file_id1}"
+        resource_id2 = f"{scan_id}/{fileset_id}/{file_id2}"
+        user1 = "user1"
+
+        # Acquire exclusive locks on different files
+        with self.lock_manager.acquire_lock(resource_id1, LockType.EXCLUSIVE, user1, LockLevel.FILE):
+            with self.lock_manager.acquire_lock(resource_id2, LockType.EXCLUSIVE, user1, LockLevel.FILE):
+                # Both locks should be active
+                lock_key1 = f"{resource_id1}/file/exclusive"
+                lock_key2 = f"{resource_id2}/file/exclusive"
+                self.assertIn(lock_key1, self.lock_manager._active_locks)
+                self.assertIn(lock_key2, self.lock_manager._active_locks)
+                
+                # Check that both lock files exist
+                lock_file1 = self.lock_manager._get_lock_file_path(resource_id1, LockLevel.FILE)
+                lock_file2 = self.lock_manager._get_lock_file_path(resource_id2, LockLevel.FILE)
+                self.assertTrue(os.path.exists(lock_file1))
+                self.assertTrue(os.path.exists(lock_file2))
 
 
 class TestFSDBLock(unittest.TestCase):

--- a/src/commons/tests/test_fsdb_lock.py
+++ b/src/commons/tests/test_fsdb_lock.py
@@ -15,7 +15,8 @@ from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.fsdb.lock import LockError
 from plantdb.commons.fsdb.lock import LockTimeoutError
 from plantdb.commons.fsdb.lock import LockType
-from plantdb.commons.fsdb.lock import ScanLockManager
+from plantdb.commons.fsdb.lock import LockManager
+from plantdb.commons.fsdb.lock import LockLevel
 from plantdb.commons.test_database import setup_test_database
 
 
@@ -45,14 +46,14 @@ class TestLockTimeoutError(unittest.TestCase):
         self.assertEqual(str(error), custom_message)
 
 
-class TestScanLockManager(unittest.TestCase):
+class TestLockManager(unittest.TestCase):
     """Test cases for the ScanLockManager class."""
 
     def setUp(self):
         """Set up a temporary directory for testing."""
         self.temp_dir = tempfile.mkdtemp()
         # Create a lock manager with a short default timeout for faster tests
-        self.lock_manager = ScanLockManager(self.temp_dir, default_timeout=1.0)
+        self.lock_manager = LockManager(self.temp_dir, default_timeout=1.0)
 
     def tearDown(self):
         """Clean up temporary files after tests."""
@@ -84,19 +85,19 @@ class TestScanLockManager(unittest.TestCase):
         scan_id = "test_scan"
         # Test for shared lock
         expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}.lock")
-        actual_path = self.lock_manager._get_lock_file_path(scan_id)
+        actual_path = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
         self.assertEqual(actual_path, expected_path)
 
         # Test for exclusive lock
         expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}.lock")
-        actual_path = self.lock_manager._get_lock_file_path(scan_id)
+        actual_path = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
         self.assertEqual(actual_path, expected_path)
 
     def test_get_lock_info_path(self):
         """Verify that _get_lock_info_path returns the correct path."""
         scan_id = "test_scan"
         expected_path = os.path.join(self.temp_dir, ".locks", f"{scan_id}.info")
-        actual_path = self.lock_manager._get_lock_info_path(scan_id)
+        actual_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
         self.assertEqual(actual_path, expected_path)
 
     @patch('fcntl.flock')
@@ -136,16 +137,16 @@ class TestScanLockManager(unittest.TestCase):
         user = "test_user"
 
         # Write lock info
-        self.lock_manager._write_lock_info(scan_id, lock_type, user)
+        self.lock_manager._write_lock_info(scan_id, lock_type, user, LockLevel.SCAN)
 
         # Check that the file exists
-        info_path = self.lock_manager._get_lock_info_path(scan_id)
+        info_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
         self.assertTrue(os.path.exists(info_path))
 
         # Verify the content of the file
         with open(info_path, 'r') as f:
             info = json.load(f)
-            self.assertEqual(info['scan_id'], scan_id)
+            self.assertEqual(info['resource_id'], scan_id)
             self.assertEqual(info['lock_type'], lock_type.value)
             self.assertEqual(info['user'], user)
             self.assertIn('timestamp', info)
@@ -153,7 +154,7 @@ class TestScanLockManager(unittest.TestCase):
             self.assertIn('thread_id', info)
 
         # Remove lock info
-        self.lock_manager._remove_lock_info(scan_id)
+        self.lock_manager._remove_lock_info(scan_id, LockLevel.SCAN)
 
         # Check that the file no longer exists
         self.assertFalse(os.path.exists(info_path))
@@ -164,28 +165,28 @@ class TestScanLockManager(unittest.TestCase):
         user = "test_user"
 
         # Acquire a shared lock
-        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user):
+        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user, LockLevel.SCAN):
             # Check that the lock file exists
-            lock_file = self.lock_manager._get_lock_file_path(scan_id)
+            lock_file = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
             self.assertTrue(os.path.exists(lock_file))
 
             # Check that the lock is registered in active locks
-            lock_key = f"{scan_id}_shared"
+            lock_key = f"{scan_id}/scan/shared"
             self.assertIn(lock_key, self.lock_manager._active_locks)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['type'], LockType.SHARED)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['user'], user)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['count'], 1)
 
             # Check that the lock info file exists
-            info_path = self.lock_manager._get_lock_info_path(scan_id)
+            info_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
             self.assertTrue(os.path.exists(info_path))
 
         # After the context manager exits, check that the lock is released
-        lock_file = self.lock_manager._get_lock_file_path(scan_id)
+        lock_file = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
         self.assertFalse(os.path.exists(lock_file))
-        lock_key = f"{scan_id}_shared"
+        lock_key = f"{scan_id}/scan/shared"
         self.assertNotIn(lock_key, self.lock_manager._active_locks)
-        info_path = self.lock_manager._get_lock_info_path(scan_id)
+        info_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
         self.assertFalse(os.path.exists(info_path))
 
     def test_acquire_exclusive_lock(self):
@@ -194,28 +195,28 @@ class TestScanLockManager(unittest.TestCase):
         user = "test_user"
 
         # Acquire an exclusive lock
-        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user):
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user, LockLevel.SCAN):
             # Check that the lock file exists
-            lock_file = self.lock_manager._get_lock_file_path(scan_id)
+            lock_file = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
             self.assertTrue(os.path.exists(lock_file))
 
             # Check that the lock is registered in active locks
-            lock_key = f"{scan_id}_exclusive"
+            lock_key = f"{scan_id}/scan/exclusive"
             self.assertIn(lock_key, self.lock_manager._active_locks)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['type'], LockType.EXCLUSIVE)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['user'], user)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['count'], 1)
 
             # Check that the lock info file exists
-            info_path = self.lock_manager._get_lock_info_path(scan_id)
+            info_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
             self.assertTrue(os.path.exists(info_path))
 
         # After the context manager exits, check that the lock is released
-        lock_file = self.lock_manager._get_lock_file_path(scan_id)
+        lock_file = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
         self.assertFalse(os.path.exists(lock_file))
-        lock_key = f"{scan_id}_exclusive"
+        lock_key = f"{scan_id}/scan/exclusive"
         self.assertNotIn(lock_key, self.lock_manager._active_locks)
-        info_path = self.lock_manager._get_lock_info_path(scan_id)
+        info_path = self.lock_manager._get_lock_info_path(scan_id, LockLevel.SCAN)
         self.assertFalse(os.path.exists(info_path))
 
     def test_acquire_multiple_shared_locks(self):
@@ -225,21 +226,21 @@ class TestScanLockManager(unittest.TestCase):
         user2 = "user2"
 
         # Acquire a shared lock with user1
-        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1):
+        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1, LockLevel.SCAN):
             # Acquire another shared lock with user2
-            with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2):
+            with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, LockLevel.SCAN):
                 # Check that the lock is registered in active locks with a count of 2
-                lock_key = f"{scan_id}_shared"
+                lock_key = f"{scan_id}/scan/shared"
                 self.assertIn(lock_key, self.lock_manager._active_locks)
                 self.assertEqual(self.lock_manager._active_locks[lock_key]['count'], 2)
 
             # After user2's lock is released, the count should be 1
-            lock_key = f"{scan_id}_shared"
+            lock_key = f"{scan_id}/scan/shared"
             self.assertIn(lock_key, self.lock_manager._active_locks)
             self.assertEqual(self.lock_manager._active_locks[lock_key]['count'], 1)
 
         # After both locks are released, the lock should be gone
-        lock_key = f"{scan_id}_shared"
+        lock_key = f"{scan_id}/scan/shared"
         self.assertNotIn(lock_key, self.lock_manager._active_locks)
 
     def test_exclusive_lock_prevents_shared(self):
@@ -249,10 +250,10 @@ class TestScanLockManager(unittest.TestCase):
         user2 = "user2"
 
         # Acquire an exclusive lock with user1
-        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1):
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1, LockLevel.SCAN):
             # Try to acquire a shared lock with user2 (should time out)
             with self.assertRaises(LockTimeoutError):
-                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, LockLevel.SCAN, timeout=0.5):
                     pass
 
     def test_shared_lock_prevents_exclusive(self):
@@ -262,10 +263,10 @@ class TestScanLockManager(unittest.TestCase):
         user2 = "user2"
 
         # Acquire a shared lock with user1
-        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1):
+        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1, LockLevel.SCAN):
             # Try to acquire an exclusive lock with user2 (should time out)
             with self.assertRaises(LockTimeoutError):
-                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, LockLevel.SCAN, timeout=0.5):
                     pass
 
     def test_exclusive_lock_prevents_exclusive(self):
@@ -275,10 +276,10 @@ class TestScanLockManager(unittest.TestCase):
         user2 = "user2"
 
         # Acquire an exclusive lock with user1
-        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1):
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1, LockLevel.SCAN):
             # Try to acquire another exclusive lock with user2 (should raise a LockError)
             with self.assertRaises(LockError):
-                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, LockLevel.SCAN, timeout=0.5):
                     pass
 
     def test_lock_timeout(self):
@@ -287,7 +288,7 @@ class TestScanLockManager(unittest.TestCase):
         user = "test_user"
 
         # Create a lock file and hold an exclusive lock on it
-        lock_file_path = self.lock_manager._get_lock_file_path(scan_id)
+        lock_file_path = self.lock_manager._get_lock_file_path(scan_id, LockLevel.SCAN)
         os.makedirs(os.path.dirname(lock_file_path), exist_ok=True)
 
         # Open and lock the file outside of the lock manager
@@ -298,7 +299,7 @@ class TestScanLockManager(unittest.TestCase):
             # Try to acquire the lock (should time out)
             start_time = time.time()
             with self.assertRaises(LockTimeoutError):
-                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user, LockLevel.SCAN, timeout=0.5):
                     pass
 
             # Check that it took approximately the timeout duration
@@ -313,7 +314,7 @@ class TestScanLockManager(unittest.TestCase):
     def test_get_lock_status_no_locks(self):
         """Verify that get_lock_status returns correct status when no locks exist."""
         scan_id = "test_scan"
-        status = self.lock_manager.get_lock_status(scan_id)
+        status = self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
         self.assertEqual(status, {'exclusive': None, 'shared': []})
 
     def test_get_lock_status_with_exclusive_lock(self):
@@ -322,10 +323,11 @@ class TestScanLockManager(unittest.TestCase):
         user = "test_user"
 
         # Acquire an exclusive lock
-        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user):
+        with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user, LockLevel.SCAN):
             # Get the lock status
-            status = self.lock_manager.get_lock_status(scan_id)
-
+            status = self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
+            print(self.lock_manager._active_locks.items())
+            print(status)
             # Check the status
             self.assertIsNotNone(status['exclusive'])
             self.assertEqual(status['exclusive']['user'], user)
@@ -339,10 +341,10 @@ class TestScanLockManager(unittest.TestCase):
         user2 = "user2"
 
         # Acquire shared locks
-        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1):
-            with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2):
+        with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1, LockLevel.SCAN):
+            with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, LockLevel.SCAN):
                 # Get the lock status
-                status = self.lock_manager.get_lock_status(scan_id)
+                status = self.lock_manager.get_lock_status(scan_id, LockLevel.SCAN)
 
                 # Check the status
                 self.assertIsNone(status['exclusive'])
@@ -358,8 +360,8 @@ class TestScanLockManager(unittest.TestCase):
         user = "test_user"
 
         # Acquire multiple locks
-        with self.lock_manager.acquire_lock(scan_id1, LockType.SHARED, user):
-            with self.lock_manager.acquire_lock(scan_id2, LockType.EXCLUSIVE, user):
+        with self.lock_manager.acquire_lock(scan_id1, LockType.SHARED, user, LockLevel.SCAN):
+            with self.lock_manager.acquire_lock(scan_id2, LockType.EXCLUSIVE, user, LockLevel.SCAN):
                 # Check that the locks exist
                 self.assertEqual(len(self.lock_manager._active_locks), 2)
 
@@ -371,8 +373,8 @@ class TestScanLockManager(unittest.TestCase):
                 self.assertEqual(len(self.lock_manager._lock_files), 0)
 
                 # Check that the lock files are removed
-                lock_file1 = self.lock_manager._get_lock_file_path(scan_id1)
-                lock_file2 = self.lock_manager._get_lock_file_path(scan_id2)
+                lock_file1 = self.lock_manager._get_lock_file_path(scan_id1, LockLevel.SCAN)
+                lock_file2 = self.lock_manager._get_lock_file_path(scan_id2, LockLevel.SCAN)
                 self.assertFalse(os.path.exists(lock_file1))
                 self.assertFalse(os.path.exists(lock_file2))
 
@@ -383,7 +385,7 @@ class TestConcurrentLocks(unittest.TestCase):
     def setUp(self):
         """Set up a temporary directory for testing."""
         self.temp_dir = tempfile.mkdtemp()
-        self.lock_manager = ScanLockManager(self.temp_dir, default_timeout=2.0)
+        self.lock_manager = LockManager(self.temp_dir, default_timeout=2.0)
 
     def tearDown(self):
         """Clean up temporary files after tests."""
@@ -404,7 +406,7 @@ class TestConcurrentLocks(unittest.TestCase):
 
         def acquire_shared_lock(user):
             try:
-                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user):
+                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user, LockLevel.SCAN):
                     results.append(user)
                     time.sleep(0.5)  # Hold the lock for a bit
             except Exception as e:
@@ -435,7 +437,7 @@ class TestConcurrentLocks(unittest.TestCase):
         def acquire_exclusive_lock(user):
             try:
                 # Use a short timeout for the threads
-                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user, LockLevel.SCAN, timeout=0.5):
                     results.append(user)
                     # Hold the lock longer than the timeout of other threads (1.0s > 0.5s)
                     time.sleep(1.0)
@@ -469,7 +471,7 @@ class TestConcurrentLocks(unittest.TestCase):
 
         def acquire_exclusive_lock():
             try:
-                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1, timeout=60.):
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user1, LockLevel.SCAN, timeout=60.):
                     # Hold the exclusive lock for a while
                     time.sleep(0.5)
                     # Try to acquire a shared lock (this should not happen while exclusive holds)
@@ -480,7 +482,7 @@ class TestConcurrentLocks(unittest.TestCase):
         def acquire_shared_lock():
             try:
                 # Try to acquire a shared lock while exclusive is held
-                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user2, LockLevel.SCAN, timeout=0.5):
                     results.append("shared_acquired")
             except Exception as e:
                 errors.append(str(e))
@@ -516,7 +518,7 @@ class TestConcurrentLocks(unittest.TestCase):
 
         def acquire_shared_lock():
             try:
-                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1):
+                with self.lock_manager.acquire_lock(scan_id, LockType.SHARED, user1, LockLevel.SCAN):
                     # Hold the shared lock for a while
                     time.sleep(0.5)
                     results.append("shared_held")
@@ -526,7 +528,7 @@ class TestConcurrentLocks(unittest.TestCase):
         def acquire_exclusive_lock():
             try:
                 # Try to acquire an exclusive lock while shared is held
-                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, timeout=0.5):
+                with self.lock_manager.acquire_lock(scan_id, LockType.EXCLUSIVE, user2, LockLevel.SCAN, timeout=0.5):
                     results.append("exclusive_acquired")
             except Exception as e:
                 errors.append(str(e))

--- a/src/commons/tests/test_io.py
+++ b/src/commons/tests/test_io.py
@@ -131,13 +131,10 @@ class TestIODummy(DummyDBTestCase):
     def test_write_vol(self):
         vol = rng.random((50, 50, 200))
         self._test_write_file(vol, 'volume')
-        self._test_write_file(vol, 'volume', compress=False)
 
     def test_read_vol(self):
         vol = rng.random((50, 50, 200))
         fpath, obj, _ = self._test_write_file(vol, 'volume')
-        self._test_read_file(fpath, obj, 'volume')
-        fpath, obj, _ = self._test_write_file(vol, 'volume', compress=False)
         self._test_read_file(fpath, obj, 'volume')
 
     def test_write_npz(self):

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -10,6 +10,7 @@ Server-side component of the ROMI plant database system.
 Provides a robust REST API server implementation for managing plant phenotyping data.
 
 Features include:
+
 - File system database management
 - Data synchronization services
 - Command-line tools for database management
@@ -33,19 +34,84 @@ API documentation for the `plantdb` library is available at: [https://romi.githu
 
 We strongly recommend using isolated environments to install ROMI libraries.
 
+### Python venv
+
+To create a new Python virtual environment for PlantDB:
+
+```shell
+python -m venv .venv         # create a pyvenv named `.venv` in the current directory
+source .venv/bin/activate    # activate the virtual environment
+pip install ipython          # optional interactive workbench
+```
+
+### Conda
+
 This documentation uses `conda` as both an environment and package manager.
-If you don't have`miniconda3` installed, please refer to the [official documentation](https://docs.conda.io/en/latest/miniconda.html).
+If you don't have `miniconda3` installed, please refer to the [official documentation](https://docs.conda.io/en/latest/miniconda.html).
 
 To create a new conda environment for PlantDB:
+
 ``` shell
 conda create -n plantdb 'python=3.10' ipython
 ```
 
+To use it, you need to activate it with:
+
+```shell
+conda activate plantdb  # activate your environment
+```
+
 ## Installation
+
+### User – Pre Built Packages
 
 Activate your environment and install the packages using `pip`:
 
 ``` shell
-conda activate plantdb  # activate your environment first!
 pip install plantdb.commons plantdb.server plantdb.client
 ```
+
+### Developers – From Sources
+
+To contribute to the development, you will need to install the sources:
+
+```shell
+git clone https://github.com/romi/plantdb.git
+cd plantdb
+# Install 'plantdb.commons'...
+pip install -e src/commons/.[io]
+# Install 'plantdb.server'...
+pip install -e src/server/.
+# Install 'plantdb.client'...
+pip install -e src/client/
+```
+
+## Usage
+
+### Test with Toy Dataset
+
+To run the server with a temporary test database in debug mode:
+
+```shell
+python fsdb_rest_api.py --test --debug
+```
+
+### Development
+
+To start the REST API server for a local plant database:
+
+```shell
+python fsdb_rest_api.py --db_location /path/to/your/database --host 127.0.0.1 --port 8080
+```
+
+### Production
+
+To start the REST API server in production:
+
+```shell
+uwsgi --http :5000 --module plantdb.server.cli.wsgi:application --callable application --master
+```
+
+For detailed usage instructions and a full endpoint reference, see:
+ - [How to Run the REST API](https://romi.github.io/plantdb/site/rest_api/rest_api_usage/)
+ - [REST API Endpoints](https://romi.github.io/plantdb/site/rest_api/rest_api_endpoints/)

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,4 +1,4 @@
-# [![ROMI_logo](../../docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / PlantDB.server
+# [![ROMI_logo](https://github.com/romi/plantdb/blob/ab29155f0bc0ad755c3455c4db3eb56c4bbd1b0e/docs/assets/images/ROMI_logo_green_25.svg)](https://romi-project.eu) / PlantDB.server
 
 [![Licence](https://img.shields.io/github/license/romi/plantdb?color=lightgray)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 [![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fromi%2Fplantdb%2Frefs%2Fheads%2Fdev%2Fsrc%2Fcommons%2Fpyproject.toml&logo=python&logoColor=white)]()

--- a/src/server/plantdb/server/api/assets.py
+++ b/src/server/plantdb/server/api/assets.py
@@ -246,8 +246,8 @@ class DatasetFile(Resource):
 
     See Also
     --------
-    plantdb.server.rest_api.ScansList : Resource for managing scan listings
-    plantdb.server.rest_api.File : Resource for file retrieval operations
+    plantdb.server.api.scan.ScansList : Resource for managing scan listings
+    plantdb.server.api.scan.File : Resource for file retrieval operations
     """
 
     def __init__(self, db, logger=None):
@@ -621,7 +621,7 @@ class PointCloud(Resource):
 
         See Also
         --------
-        plantdb.server.rest_api.sanitize_name : Input sanitization & validation function.
+        plantdb.server.core.security.sanitize_name : Input sanitization & validation function.
         plantdb.server.webcache.pointcloud_path : Point cloud path resolution function with caching and downsampling options.
 
         Examples
@@ -897,7 +897,7 @@ class Mesh(Resource):
 
         See Also
         --------
-        plantdb.server.rest_api.sanitize_name : Function used to validate input parameters
+        plantdb.server.core.security.sanitize_name : Function used to validate input parameters
         plantdb.server.webcache.mesh_path : Function to retrieve mesh file path
 
         Examples
@@ -1146,7 +1146,7 @@ class Sequence(Resource):
 
         See Also
         --------
-        plantdb.server.rest_api.sanitize_name : Function used to validate and clean scan_id
+        plantdb.server.core.security.sanitize_name : Function used to validate and clean scan_id
         plantdb.server.rest_api.compute_fileset_matches : Function to match filesets with tasks
 
         Examples

--- a/src/server/plantdb/server/api/base.py
+++ b/src/server/plantdb/server/api/base.py
@@ -339,7 +339,7 @@ class Refresh(Resource):
 
         See Also
         --------
-        plantdb.server.rest_api.rate_limit
+        plantdb.server.core.security.rate_limit
         plantsb.fsdb.FSDB.reload
 
         Examples

--- a/src/server/plantdb/server/api/scan.py
+++ b/src/server/plantdb/server/api/scan.py
@@ -223,7 +223,7 @@ class ScansTable(Resource):
 
     See Also
     --------
-    plantdb.server.rest_api.get_scan_info : Function used to extract information for each scan
+    plantdb.server.services.scan.get_scan_info : Function used to extract information for each scan
     """
 
     def __init__(self, db, logger=None):
@@ -303,7 +303,7 @@ class ScansTable(Resource):
         for scan_id in scans_list:
             try:
                 scan = self.db.get_scan(scan_id, **kwargs)
-                scan_info = get_scan_info(scan, logger=self.logger)
+                scan_info = get_scan_info(scan, logger=self.logger, **kwargs)
             except NoAuthUserError as e:
                 return {'message': str(e)}, 401  # HTTP 401 Unauthorized (authentication)
             except ScanNotFoundError as e:
@@ -335,8 +335,8 @@ class Scan(Resource):
 
     See Also
     --------
-    plantdb.server.rest_api.get_scan_info : Function used to collect and format scan information
-    plantdb.server.rest_api.sanitize_name : Function used to validate and clean scan IDs
+    plantdb.server.services.scan.get_scan_info : Function used to collect and format scan information
+    plantdb.server.core.security.sanitize_name : Function used to validate and clean scan IDs
     """
 
     def __init__(self, db, logger=None):

--- a/src/server/plantdb/server/cli/fsdb_rest_api.py
+++ b/src/server/plantdb/server/cli/fsdb_rest_api.py
@@ -69,7 +69,6 @@ python fsdb_rest_api.py --help
 ```
 """
 
-import argparse
 import atexit
 import logging
 import os
@@ -80,6 +79,7 @@ from time import sleep
 from typing import Optional
 from typing import Union
 
+import click
 from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api
@@ -97,67 +97,30 @@ from plantdb.server.api.assets import Archive
 from plantdb.server.api.assets import CurveSkeleton
 from plantdb.server.api.assets import DatasetFile
 from plantdb.server.api.assets import FilePath
+from plantdb.server.api.assets import Image
+from plantdb.server.api.assets import Mesh
+from plantdb.server.api.assets import PointCloud
+from plantdb.server.api.assets import PointCloudGroundTruth
+from plantdb.server.api.assets import Sequence
+from plantdb.server.api.auth import CreateApiToken
+from plantdb.server.api.auth import Login
+from plantdb.server.api.auth import Logout
+from plantdb.server.api.auth import Register
+from plantdb.server.api.auth import TokenRefresh
+from plantdb.server.api.auth import TokenValidation
+from plantdb.server.api.base import HealthCheck
+from plantdb.server.api.base import Home
+from plantdb.server.api.base import Refresh
 from plantdb.server.api.file import File
 from plantdb.server.api.file import FileMetadata
 from plantdb.server.api.fileset import Fileset
 from plantdb.server.api.fileset import FilesetFiles
 from plantdb.server.api.fileset import FilesetMetadata
-from plantdb.server.api.base import HealthCheck
-from plantdb.server.api.base import Home
-from plantdb.server.api.assets import Image
-from plantdb.server.api.auth import Login
-from plantdb.server.api.auth import CreateApiToken
-from plantdb.server.api.auth import Logout
-from plantdb.server.api.assets import Mesh
-from plantdb.server.api.assets import PointCloud
-from plantdb.server.api.assets import PointCloudGroundTruth
-from plantdb.server.api.base import Refresh
-from plantdb.server.api.auth import Register
 from plantdb.server.api.scan import Scan
 from plantdb.server.api.scan import ScanFilesets
 from plantdb.server.api.scan import ScanMetadata
 from plantdb.server.api.scan import ScansList
 from plantdb.server.api.scan import ScansTable
-from plantdb.server.api.assets import Sequence
-from plantdb.server.api.auth import TokenRefresh
-from plantdb.server.api.auth import TokenValidation
-
-
-def parsing() -> argparse.ArgumentParser:
-    """Create and configure an argument parser for a REST API server.
-
-    Returns
-    -------
-    argparse.ArgumentParser
-        The configured argument parser capable of parsing and retrieving command-line arguments.
-    """
-    parser = argparse.ArgumentParser(description='Serve a local plantdb database (FSDB) through a REST API.')
-    parser.add_argument('-db', '--db_location', type=str, default=os.environ.get("ROMI_DB", None),
-                        help='location of the database to serve.')
-
-    app_args = parser.add_argument_group("webserver arguments")
-    app_args.add_argument('--host', type=str, default="0.0.0.0",
-                          help="hostname to listen on; defaults to '0.0.0.0'.")
-    app_args.add_argument('--port', type=int, default=5000,
-                          help="port of the webserver; defaults to '5000'.")
-    app_args.add_argument('--debug', action='store_true',
-                          help="enable debug mode.")
-    app_args.add_argument('--proxy', action='store_true',
-                          help="use when the server sits behind a reverse proxy.")
-
-    misc_args = parser.add_argument_group("other arguments")
-    misc_args.add_argument("--test", action='store_true',
-                           help="set up a temporary test database before starting the REST API.")
-    misc_args.add_argument("--empty", action='store_true',
-                           help="do not populate the test database with toy datasets.")
-    misc_args.add_argument("--models", action='store_true',
-                           help="include trained CNN model in the test database.")
-
-    log_opt = parser.add_argument_group("logging options")
-    log_opt.add_argument("--log-level", dest="log_level", type=str, default=DEFAULT_LOG_LEVEL, choices=LOG_LEVELS,
-                         help="logging level; defaults to 'INFO'.")
-
-    return parser
 
 
 def _get_env_secret(var_name: str, logger: logging.Logger) -> str:
@@ -519,6 +482,7 @@ def rest_api(db_path: Optional[Union[str, Path]], proxy: bool = False, url_prefi
             refresh_timeout=refresh_timeout,
             max_concurrent_sessions=max_sessions,
         ),
+        log_level = log_level,
     )
     logger.info(f"Connecting to local plant database at '{db.path()}'.")
     db.connect()
@@ -532,25 +496,62 @@ def rest_api(db_path: Optional[Union[str, Path]], proxy: bool = False, url_prefi
     return app
 
 
-def main():
-    """Entry point for the REST API server.
+# ---------------------------------------------------------------------------
+# Click command‑line interface
+# ---------------------------------------------------------------------------
 
-    Parses command line arguments, builds the Flask application, and starts the development server
-    with the supplied host/port and debug settings.
-    """
-    parser = parsing()
-    args = parser.parse_args()
-
+@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.option('-db', '--db_location', 'db_location',
+              type=click.Path(),
+              default=os.getenv("ROMI_DB", None),
+              help='Location of the database to serve.')
+@click.option('--host',
+              default="0.0.0.0",
+              show_default=True,
+              help="Hostname to listen on; defaults to '0.0.0.0'.")
+@click.option('--port',
+              type=int,
+              default=5000,
+              show_default=True,
+              help="Port of the webserver; defaults to '5000'.")
+@click.option('--debug',
+              is_flag=True,
+              default=False,
+              help="Enable debug mode.")
+@click.option('--proxy',
+              is_flag=True,
+              default=False,
+              help="Use when the server sits behind a reverse proxy.")
+@click.option('--test',
+              is_flag=True,
+              default=False,
+              help="Set up a temporary test database before starting the REST API.")
+@click.option('--empty',
+              is_flag=True,
+              default=False,
+              help="Do not populate the test database with toy datasets.")
+@click.option('--models',
+              is_flag=True,
+              default=False,
+              help="Include trained CNN model in the test database.")
+@click.option('--log-level',
+              type=click.Choice(LOG_LEVELS, case_sensitive=False),
+              default=DEFAULT_LOG_LEVEL,
+              show_default=True,
+              help="Logging level; defaults to 'INFO'.")
+def main(db_location, host, port, debug, proxy, test, empty, models, log_level):
+    """Entry point for the REST API server using Click."""
+    print(f"{log_level.upper()=}")
     app = rest_api(
-        db_path=args.db_location,
-        proxy=args.proxy,
-        log_level=args.log_level,
-        test=args.test,
-        empty=args.empty,
-        models=args.models,
+        db_path=db_location,
+        proxy=proxy,
+        log_level=log_level.upper(),
+        test=test,
+        empty=empty,
+        models=models,
     )
-    # Start the Flask application:
-    app.run(host=args.host, port=args.port, debug=args.debug)
+    # Start the Flask development server.
+    app.run(host=host, port=port, debug=debug)
 
 
 if __name__ == '__main__':

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plantdb.server"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
     "plantdb.commons",
     "bcrypt",


### PR DESCRIPTION
### Summary
This pull request introduces a collection of enhancements focused on improving user interaction, authentication flexibility, and file system database (FSDB) locking:

- **Interactive cleanup of invalid scans**
  - Added `yes_no_choice` utility and integrated prompts in `file_ops.py`.
  - Guarded prompts with `EOFError` handling for non‑interactive environments.
  - Utilized pre‑computed bad‑scan counts and performed conditional deletion.

- **User database handling**
  - Implemented prompt to replace outdated user DB files.
  - Ensured fresh user DB creation by resetting `self.users`.
  - Added `yes_no_choice` import and updated docstrings.

- **No‑auth support**
  - Introduced `NoAuthSessionManager` for test and guest scenarios.
  - Integrated environment variable `ROMI_DB_NOAUTH` checks.
  - Updated `FSDB` initialization to select the appropriate session manager.

- **Generic multi‑level lock manager**
  - Refactored `ScanLockManager` to `LockManager` with `LockLevel` enum (`SCAN`, `FILESET`, `FILE`).
  - Updated all lock acquisition, status, and release calls to include lock level.
  - Adjusted metadata methods to acquire shared/exclusive locks using the new manager.

- **Logging and utilities**
  - Added configurable `log_level` handling.
  - Switched several informational logs to debug level to reduce noise.
  - Updated CLI to use Click and expose log‑level option.

- **IO simplifications**
  - Removed `tifffile` dependency and compression handling from `write_volume`.
  - Updated documentation and test suite accordingly.

- **Miscellaneous**
  - Bumped project version to **0.15.1**.
  - Ensured FSDB config files are created with `pathlib` paths.
  - Minor docstring, type‑hint, and formatting refinements.

These changes collectively make the FSDB more robust, user‑friendly, and easier to test in various environments.