### PR TITLE
Upgrade GitHub Actions to latest versions in CI workflows

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Set up Miniconda environment
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true   # Ensure conda is updated to latest version
           python-version: "3.10"    # Specify Python version for the environment

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,23 +26,23 @@ jobs:
     steps:
       # Step 1: Get the repository code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Set up Docker Buildx for multi-platform builds and build caching
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Step 3: Extract metadata to generate Docker tags and labels
       - name: Extract metadata (tags, labels) for Docker
         id: meta  # Set ID to reference this step's outputs later
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: roboticsmicrofarms/plantdb  # Target Docker image name
           tags: type=sha,format=short,prefix=  # Create tags from git SHA (short format)
 
       # Step 4: Build the Docker image and save to local tar file
       - name: Build and Cache docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .  # Build context is repository root
           file: docker/Dockerfile  # Path to Dockerfile
@@ -51,7 +51,7 @@ jobs:
 
       # Step 5: Save the built image as a workflow artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myimage
           path: /tmp/myimage.tar
@@ -68,14 +68,14 @@ jobs:
 
       # Step 7: Authenticate with Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}  # Use stored credentials
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Step 8: Push the image to Docker Hub with both SHA tag and "latest" tag
       - name: Push as latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true  # Actually push to registry

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       #  Step 1: Clone the repository code
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Install Python runtime
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.9'  # Specify Python version for docs build
+          python-version: '3.10'  # Specify Python version for docs build
           cache: 'pip'  # Enable caching of pip packages to speed up workflow
 
       # Step 3: Install the sources with documentation dependencies
@@ -38,7 +38,7 @@ jobs:
 
       # Step 5: Deploy to GitHub Pages
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}  # Use auto-generated token for authentication
           publish_dir: ./site  # Deploy the mkdocs output directory

--- a/.github/workflows/pip_build_client.yml
+++ b/.github/workflows/pip_build_client.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Set up Python environment
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -38,7 +38,7 @@ jobs:
 
       # Step 5: Save the built package artifacts for the next job
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: src/client/dist/  # Directory containing wheel and source distribution
@@ -56,7 +56,7 @@ jobs:
     steps:
       # Step 1: Retrieve the package artifacts from the previous job
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: src/client/dist/

--- a/.github/workflows/pip_build_commons.yml
+++ b/.github/workflows/pip_build_commons.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Set up Python environment
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -38,7 +38,7 @@ jobs:
 
       # Step 5: Save the built package artifacts for the next job
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: src/commons/dist/  # Directory containing wheel and source distribution
@@ -56,7 +56,7 @@ jobs:
     steps:
       # Step 1: Retrieve the package artifacts from the previous job
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: src/commons/dist/

--- a/.github/workflows/pip_build_server.yml
+++ b/.github/workflows/pip_build_server.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Step 2: Set up Python environment
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -38,7 +38,7 @@ jobs:
 
       # Step 5: Save the built package artifacts for the next job
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: src/server/dist/  # Directory containing wheel and source distribution
@@ -56,7 +56,7 @@ jobs:
     steps:
       # Step 1: Retrieve the package artifacts from the previous job
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: src/server/dist/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 


### PR DESCRIPTION
- Bump `actions/checkout` from **v4** to **v6** in all workflow files (`gh-pages.yml`, `docker.yml`, `pull_request.yml`, `conda.yml`, `pip_build_server.yml`, `pip_build_commons.yml`, `pip_build_client.yml`).
- Update Python setup action:
  - `actions/setup-python` to **v6** (and Python version to **3.10** where applicable) in `gh-pages.yml`, `pip_build_server.yml`, `pip_build_commons.yml`, `pip_build_client.yml`.
- Upgrade documentation deployment action:
  - `peaceiris/actions-gh-pages` to **v4** in `gh-pages.yml`.
- Refresh Docker‑related actions in `docker.yml`:
  - `docker/setup-buildx-action` to **v4**
  - `docker/metadata-action` to **v6**
  - `docker/build-push-action` to **v7**
  - `docker/login-action` to **v4**
- Switch artifact actions to latest versions:
  - `actions/upload-artifact` to **v7**
  - `actions/download-artifact` to **v8** across relevant workflows.
- Update Conda setup action:
  - `conda-incubator/setup-miniconda` to **v4** in `conda.yml`.