### PR TITLE
Migrate FSDB CLIs to Click with configurable logging

### DIFF
--- a/src/client/plantdb/client/cli/fsdb_rest_api_sync.py
+++ b/src/client/plantdb/client/cli/fsdb_rest_api_sync.py
@@ -9,12 +9,12 @@ It ensures data consistency and aids in migrating or backing up scan data effici
 
 ## Key Features
 
-- **Command-line Interface (CLI)**: Includes an argument parser for easy configuration of source and target databases.
+- **Command-line Interface (CLI)**: Uses `click` for easy configuration of source and target databases.
 - **URL Validation**: Verifies the format and accessibility of the provided database URLs.
 - **Scan Synchronization**: Retrieves scan archives from the source database and uploads them to the target database.
 - **REST API Integration**: Utilizes REST API calls for secure and efficient data transfer.
 - **Progress Tracking**: Displays a progress bar with `tqdm` to show transfer status for each scan.
-- **Logging**: Offers informational and error logging to provide feedback during the synchronization process.
+- **Configurable logging**: choose from predefined log levels to control output verbosity.
 - **Error Handling**: Handles common errors such as invalid URLs, inaccessible ports, and connectivity issues.
 
 ## Usage Examples
@@ -23,15 +23,16 @@ To synchronize two FSDB databases, run the script from the command line with the
 Temporary files are stored in the `/tmp` directory during the transfer process.
 
 ```bash
-python fsdb_rest_api_sync.py 192.168.1.1:5000 192.168.1.2:5000
+fsdb_rest_api_sync 192.168.1.1:5000 192.168.1.2:5000
 ```
 
 This command connects the origin database at `192.168.1.1:5000` to the target database at `192.168.1.2:5000` and transfers all scan archives.
 
 To filter the transferred scans based on a regular expression, use the `--filter` optional argument.
 For example, to transfer only scans with names starting with 'virtual_':
+
 ```shell
-python fsdb_rest_api_sync.py 192.168.1.1:5000 192.168.1.2:5000 --filter 'virtual_*'
+fsdb_rest_api_sync 192.168.1.1:5000 192.168.1.2:5000 --filter 'virtual_*'
 ```
 
 ## Testing
@@ -60,12 +61,13 @@ For example:
 
 """
 
-import argparse
+import os
 import re
 from pathlib import Path
 from urllib.parse import urlparse
 
-from requests.exceptions import HTTPError
+import click
+from requests import HTTPError
 from tqdm import tqdm
 
 from plantdb.client.rest_api.requests import request_archive_download
@@ -77,30 +79,41 @@ from plantdb.commons.log import DEFAULT_LOG_LEVEL
 from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
+# Create a logger and set the environment variable
+os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
-def parsing():
-    """Parses command line arguments for database synchronization.
 
-    Returns
-    -------
-    argparse.ArgumentParser
-        An argument parser configured for FSDB synchronization.
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.argument('origin', type=str)
+@click.argument('target', type=str)
+@click.option('--filter', type=str, default=None,
+              help='optional regular expression to filter scan names.')
+@click.option(
+    "--log-level",
+    type=click.Choice(LOG_LEVELS, case_sensitive=False),
+    default=DEFAULT_LOG_LEVEL,
+    show_default=True,
+    help="Logging level.",
+)
+def main(origin, target, filter_pattern, log_level):
+    """FSDB Synchronization via REST API
+
+    Transfer dataset from an origin FSDB database towards a target using REST API.
+
+    ORIGIN is the source database URL, as "host:port".
+    TARGET is the target database URL, as "host:port".
     """
-    parser = argparse.ArgumentParser(
-        description='Transfer dataset from an origin FSDB database towards a target using REST API.')
-    parser.add_argument('origin', type=str,
-                        help='source database URL, as "host:port".')
-    parser.add_argument('target', type=str,
-                        help='target database URL, as "host:port".')
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(log_level)
 
-    parser.add_argument('--filter', type=str, default=None,
-                        help='optional regular expression to filter scan names.')
+    # Validate the availability of origin and target database URLs
+    is_server_available(origin)
+    is_server_available(target)
 
-    log_opt = parser.add_argument_group("Logging options")
-    log_opt.add_argument("--log-level", dest="log_level", type=str, default=DEFAULT_LOG_LEVEL, choices=LOG_LEVELS,
-                         help="Level of message logging, defaults to 'INFO'.")
-
-    return parser
+    # Synchronize scan archives between the origin and target databases
+    sync_scan_archives(origin, target, filter_pattern, log_level)
 
 
 def filter_scan(scan_list, filter_pattern, logger):
@@ -185,42 +198,22 @@ def sync_scan_archives(origin_url, target_url, filter_pattern=None, log_level=DE
             continue
         logger.debug(f"Transferring scan '{scan_id}'...")
         # Download from origin DB via REST API
-        f_path, msg = request_archive_download(scan_id, out_dir='/tmp', host=origin_host, port=origin_port)
+        f_path, msg = request_archive_download(origin_host, scan_id, '/tmp', port=origin_port)
         logger.debug(msg)
         # Upload to target DB via REST API
-        msg = request_archive_upload(scan_id, f_path, host=target_host, port=target_port)
+        msg = request_archive_upload(target_host, scan_id, f_path, port=target_port)
         logger.debug(msg)
         # Delete the temporary file
         Path(f_path).unlink()
         # Refresh the scan in the target to load its infos:
         try:
-            success, msg = request_refresh(scan_id, host=target_host, port=target_port)
+            success, msg = request_refresh(target_host, scan_id, port=target_port)
         except HTTPError as e:
             logger.error(f"Error refreshing target database for scan '{scan_id}': {e}")
             continue
         logger.debug(msg)
 
     return
-
-
-def main():
-    """Main execution function.
-
-    This function orchestrates the parsing of command-line arguments, validation of the
-    provided database URLs, and the synchronization of scan archives between the origin
-    and target databases.
-    """
-    # Parse command-line arguments using the parsing function
-    parser = parsing()
-    # Extract the parsed arguments
-    args = parser.parse_args()
-
-    # Validate the availability of origin and target database URLs
-    is_server_available(args.origin)
-    is_server_available(args.target)
-
-    # Synchronize scan archives between the origin and target databases
-    sync_scan_archives(args.origin, args.target, args.filter, args.log_level)  # Perform synchronization
 
 
 if __name__ == '__main__':

--- a/src/client/plantdb/client/sync_app/app.py
+++ b/src/client/plantdb/client/sync_app/app.py
@@ -42,11 +42,12 @@ between different database types (local, SSH, HTTP).
 ```
 
 """
-import argparse
+import os
 import time
 import traceback
 from pathlib import Path
 
+import click
 import dash_bootstrap_components as dbc
 import paramiko
 import requests
@@ -59,10 +60,17 @@ from dash import ctx
 from dash import dcc
 from dash import html
 
+from plantdb.commons.log import DEFAULT_LOG_LEVEL
+from plantdb.commons.log import get_logger
+
+# Create a logger and set the environment variable
+os.environ.setdefault('ROMI_APP_LOGGER', 'fsdb_sync_gui')
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
+
 from plantdb.client.rest_api.requests import request_scan_names_list
-from plantdb.commons.fsdb.core import FSDB
 from plantdb.client.sync import FSDBSync
 from plantdb.client.sync import config_from_url
+from plantdb.commons.fsdb.core import FSDB
 
 #: URL for the ROMI project logo used in the navigation bar
 ROMI_LOGO: str = "https://romi-project.eu/assets/logo.svg"
@@ -860,18 +868,19 @@ def start_synchronization(sync_clicks, n_intervals, selected_scans):
     return 0., "", True
 
 
-def parsing():
-    parser = argparse.ArgumentParser()
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.option("--port", type=int, default=8050, help="Port to run the web application on")
+@click.option("--debug", is_flag=True, help="Enable debug mode")
+def main(port, debug):
+    """Dash UI for FSDBSync - PlantDB Database Synchronization Tool
+    
+    A web-based user interface for synchronizing databases between different types (local, SSH, HTTP).
+    """
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(DEFAULT_LOG_LEVEL)  # Using default log level for web app
 
-    parser.add_argument("--port", type=int, default=8050)
-    parser.add_argument("--debug", action="store_true")
-    return parser
-
-
-def main():
-    parser = parsing()
-    args = parser.parse_args()
-    app.run(host="0.0.0.0", port=args.port, debug=args.debug)
+    app.run(host="0.0.0.0", port=port, debug=debug)
 
 
 if __name__ == "__main__":

--- a/src/commons/plantdb/commons/cli/fsdb_healthcheck.py
+++ b/src/commons/plantdb/commons/cli/fsdb_healthcheck.py
@@ -1,5 +1,35 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
+"""
+# FSDB Health‑Check CLI
+
+A command‑line utility that validates a local File System DataBase (FSDB) for structural consistency, reporting missing
+references, and optionally fixing them.
+It helps maintain clean, reliable scan datasets by detecting broken `files.json` entries and safely removing corrupt scans.
+
+## Key Features
+
+- **Sanity checking** of an FSDB directory, ensuring required marker files are present.
+- **Detection of missing scan references** and automatic correction of `files.json` entries.
+- **Interactive cleanup** of scans with structural problems, moving them to the OS trash after user confirmation.
+- **Selective fixing** via `--fix-missing` (remove missing references) or `--fix-extra` (future support for importing extra files).
+- **Configurable logging** with standard log‑level choices (`INFO`, `DEBUG`, etc.).
+- **Zero‑auth operation**: works on local FSDBs without needing authentication.
+
+## Usage Examples
+
+### Basic health check (read‑only)
+```shell
+fsdb_healthcheck /path/to/my_fsdb
+
+### Identify and automatically remove missing references
+```shell
+fsdb_healthcheck /path/to/my_fsdb --fix-missing
+```
+"""
+
+import os
 from logging import Logger
 from pathlib import Path
 
@@ -8,13 +38,19 @@ from click_option_group import OptionGroup
 from click_option_group import optgroup
 from send2trash import send2trash
 
+from plantdb.commons.log import get_logger
+from plantdb.commons.log import LOG_LEVELS
+from plantdb.commons.log import DEFAULT_LOG_LEVEL
+
+# Create a logger and set the environment variable
+logger = get_logger("fsdb_rest_api", log_level=DEFAULT_LOG_LEVEL)
+os.environ.setdefault('ROMI_APP_LOGGER', 'fsdb_rest_api')
+
 from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.fsdb.core import MARKER_FILE_NAME
 from plantdb.commons.fsdb.exceptions import NotAnFSDBError
 from plantdb.commons.fsdb.file_ops import _load_scan
 from plantdb.commons.fsdb.validation import _is_scan_dataset
-from plantdb.commons.log import LOG_LEVELS
-from plantdb.commons.log import get_logger
 from plantdb.commons.utils import yes_no_abort_choice
 
 
@@ -24,11 +60,11 @@ from plantdb.commons.utils import yes_no_abort_choice
 @optgroup.option('--fix', is_flag=True,
                  help="Fix all errors by removing missing references and importing extra local files.")
 @optgroup.option('--fix-missing', is_flag=True,
-                 help="Remove missing references from each scan’s <code>files.json</code>")
+                 help="Remove missing references from each scan’s `files.json`.")
 @optgroup.option('--fix-extra', is_flag=True,
                  help="Import extra local files that are missing from the fileset.")
 @optgroup.group("Logging", cls=OptionGroup)
-@optgroup.option('--log-level', 'log_level', type=click.Choice(LOG_LEVELS), default='INFO',
+@optgroup.option('--log-level', 'log_level', type=click.Choice(LOG_LEVELS), default=DEFAULT_LOG_LEVEL,
                  help="Level of message logging.", show_default=True)
 def main(fsdb_path, fix, fix_missing, fix_extra, log_level):
     """Perform a sanity check of the given local File System DataBase (FSDB).
@@ -36,9 +72,9 @@ def main(fsdb_path, fix, fix_missing, fix_extra, log_level):
     This command performs health checks on the FSDB, identifying and optionally fixing
     inconsistencies in scan references and filesets.
     """
-    # - Configure a logger from this application:
-    global logger
-    logger = get_logger('fsdb_healthcheck', log_level=log_level)  # set level from CLI option
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(log_level)
 
     # Verify provided path is a directory
     fsdb_path = Path(fsdb_path)

--- a/src/commons/plantdb/commons/cli/fsdb_healthcheck.py
+++ b/src/commons/plantdb/commons/cli/fsdb_healthcheck.py
@@ -55,7 +55,7 @@ from plantdb.commons.utils import yes_no_abort_choice
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.argument('fsdb_path', type=click.Path(exists=True))
+@click.argument('db_path', type=click.Path(exists=True))
 @optgroup.group("Fix", cls=OptionGroup)
 @optgroup.option('--fix', is_flag=True,
                  help="Fix all errors by removing missing references and importing extra local files.")
@@ -66,7 +66,7 @@ from plantdb.commons.utils import yes_no_abort_choice
 @optgroup.group("Logging", cls=OptionGroup)
 @optgroup.option('--log-level', 'log_level', type=click.Choice(LOG_LEVELS), default=DEFAULT_LOG_LEVEL,
                  help="Level of message logging.", show_default=True)
-def main(fsdb_path, fix, fix_missing, fix_extra, log_level):
+def main(db_path, fix, fix_missing, fix_extra, log_level):
     """Perform a sanity check of the given local File System DataBase (FSDB).
 
     This command performs health checks on the FSDB, identifying and optionally fixing
@@ -77,22 +77,22 @@ def main(fsdb_path, fix, fix_missing, fix_extra, log_level):
     logger.setLevel(log_level)
 
     # Verify provided path is a directory
-    fsdb_path = Path(fsdb_path)
-    if not fsdb_path.is_dir():
+    db_path = Path(db_path)
+    if not db_path.is_dir():
         logger.error("The provided path is not a directory.")
         raise ValueError("The provided path is not a directory.")
 
     # Ensure FSDB marker file exists to confirm valid FSDB
-    marker_path = fsdb_path / MARKER_FILE_NAME
+    marker_path = db_path / MARKER_FILE_NAME
     if not marker_path.is_file():
         logger.error(f"The given path does not contain the required marker file '{MARKER_FILE_NAME}'.")
         raise NotAnFSDBError(f"The given path does not refer to a valid FSDB.")
 
     # Gather scan directories (ignore hidden folders)
-    scan_dirs = [f for f in fsdb_path.iterdir() if f.is_dir() and not f.name.startswith('.')]
+    scan_dirs = [f for f in db_path.iterdir() if f.is_dir() and not f.name.startswith('.')]
     # Empty FSDB handling
     if not scan_dirs:
-        logger.warning(f"The FSDB at '{fsdb_path}' is empty.")
+        logger.warning(f"The FSDB at '{db_path}' is empty.")
         exit(0)  # Still valid as an empty FSDB
 
     # If --fix flag is set, enable missing‑reference fixing (extra fixing not yet implemented)
@@ -101,7 +101,7 @@ def main(fsdb_path, fix, fix_missing, fix_extra, log_level):
         # fix_extra = True  # TODO: write the method first!
 
     # Instantiate FSDB object without authentication
-    db = FSDB(fsdb_path, no_auth=True)
+    db = FSDB(db_path, no_auth=True)
     # do NOT use the `connect()` method
 
     if fix_missing:

--- a/src/commons/plantdb/commons/cli/fsdb_import_file.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_file.py
@@ -51,8 +51,8 @@ from plantdb.commons.fsdb.core import FSDB
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.argument('fileset', type=click.Path(exists=True))
-@click.argument('file', type=click.Path(exists=True))
+@click.argument('fileset_path', type=click.Path(exists=True))
+@click.argument('file_path', type=click.Path(exists=True))
 @click.option(
     '--metadata',
     type=click.Path(exists=True),
@@ -74,7 +74,7 @@ from plantdb.commons.fsdb.core import FSDB
     show_default=True,
     help="Logging level.",
 )
-def main(fileset, file, metadata, user, password, no_auth, log_level):
+def main(fileset_path, file_path, metadata, user, password, no_auth, log_level):
     """FSDB File Import CLI
 
     A command‑line utility that imports a single file into a specified PlantDB fileset, optionally attaching
@@ -95,11 +95,11 @@ def main(fileset, file, metadata, user, password, no_auth, log_level):
         with open(metadata, "r", encoding="utf-8") as f:
             metadata = json.load(f)
 
-    fileset_dir = Path(fileset)  # Directory representing the target fileset
-    fileset_id = fileset_dir.name  # Identifier derived from fileset folder name
-    file_id = Path(file).stem  # Identifier derived from source filename (without extension)
-    scan_id = fileset_dir.parent  # Parent directory used as scan identifier
-    db_path = fileset_dir.parent.parent  # Grandparent directory points to the database location
+    fileset_path = Path(fileset_path)  # Directory representing the target fileset
+    fileset_id = fileset_path.name  # Identifier derived from fileset folder name
+    file_id = Path(file_path).stem  # Identifier derived from source filename (without extension)
+    scan_id = fileset_path.parent  # Parent directory used as scan identifier
+    db_path = fileset_path.parent.parent  # Grandparent directory points to the database location
 
     # Initialize the database
     db = FSDB(db_path, no_auth=no_auth)
@@ -112,7 +112,7 @@ def main(fileset, file, metadata, user, password, no_auth, log_level):
     scan = db.create_scan(scan_id)
     fileset_obj = scan.create_fileset(fileset_id)
     file_obj = fileset_obj.create_file(file_id)
-    file_obj.import_file(file)
+    file_obj.import_file(file_path)
 
     if metadata is not None:
         file_obj.set_metadata(metadata)

--- a/src/commons/plantdb/commons/cli/fsdb_import_file.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_file.py
@@ -74,7 +74,7 @@ from plantdb.commons.fsdb.core import FSDB
     show_default=True,
     help="Logging level.",
 )
-def main(fileset, file, metadata, db_user, db_password, no_auth, log_level):
+def main(fileset, file, metadata, user, password, no_auth, log_level):
     """FSDB File Import CLI
 
     A command‑line utility that imports a single file into a specified PlantDB fileset, optionally attaching
@@ -87,7 +87,7 @@ def main(fileset, file, metadata, db_user, db_password, no_auth, log_level):
     logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
     logger.setLevel(log_level)
 
-    if not (no_auth or (db_user and db_password)):
+    if not (no_auth or (user and password)):
         raise click.UsageError("Requires using either the --no-auth flag or using both --user and --password")
 
     # Load metadata if a path is provided
@@ -106,8 +106,8 @@ def main(fileset, file, metadata, db_user, db_password, no_auth, log_level):
     db.connect()
 
     # Authenticate unless explicitly disabled
-    if not no_auth and (db_user and db_password):
-        db.login(db_user, db_password)
+    if not no_auth and (user and password):
+        db.login(user, password)
 
     scan = db.create_scan(scan_id)
     fileset_obj = scan.create_fileset(fileset_id)

--- a/src/commons/plantdb/commons/cli/fsdb_import_file.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_file.py
@@ -1,53 +1,124 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""Import a file as a ``File`` in a known ``Fileset``."""
+"""
+# FSDB File Import CLI
 
-import argparse
+A command‑line utility that imports a single file into a specified PlantDB fileset, optionally attaching metadata and providing configurable logging. It streamlines adding new data to a PlantDB database directly from the terminal.
+
+## Key Features
+
+- **Simple CLI interface** using `click` with positional arguments for the target fileset and source file.
+- **Optional metadata**: load a JSON file and associate its contents with the imported file.
+- **Configurable logging**: choose from predefined log levels to control output verbosity.
+- **Automatic database handling**: connects to the FSDB, creates the necessary scan/fileset/file hierarchy, imports the file, applies metadata, and cleanly disconnects.
+
+## Usage Examples
+
+### Basic import of a file into an existing fileset
+
+```shell
+fsdb_import_file /romi_db/scan001/filesetA /path/to/image_01.png
+```
+
+### Import with metadata and verbose logging
+
+```shell
+fsdb_import_file /romi_db/scan001/filesetA /path/to/image_01.png \
+    --metadata /path/to/image_01_meta.json \
+    --log-level INFO
+```
+
+"""
+
 import json
+import os
 from pathlib import Path
+
+import click
+from click_option_group import OptionGroup
+from click_option_group import optgroup
+
+from plantdb.commons.log import DEFAULT_LOG_LEVEL
+from plantdb.commons.log import LOG_LEVELS
+from plantdb.commons.log import get_logger
+
+# Create a logger and set the environment variable
+os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.fsdb.core import FSDB
 
 
-def parsing():
-    parser = argparse.ArgumentParser(description="Import a file as a ``File`` in a known ``Fileset``.")
-    parser.add_argument('--metadata', metavar='metadata', type=str, default=None,
-                        help='JSON or TOML file with metadata.')
-    parser.add_argument('file', metavar='file', type=str,
-                        help='File to add to fileset. File name will be the file id.')
-    parser.add_argument('fileset', metavar='fileset', type=str,
-                        help='Fileset folder to add the file to (/path/to/db/scan_id/fileset_id).')
-    return parser
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.argument('fileset', type=click.Path(exists=True))
+@click.argument('file', type=click.Path(exists=True))
+@click.option(
+    '--metadata',
+    type=click.Path(exists=True),
+    default=None,
+    help='Path to a JSON file with file related metadata.'
+)
+@optgroup.group("Login", cls=OptionGroup)
+@optgroup.option('-u', '--user', type=str, default=None,
+                 help="Username for FSDB login.")
+@optgroup.option('-p', '--password', type=str, default=None,
+                 help="Password for FSDB login.")
+@optgroup.option('--no-auth', is_flag=True, default=False,
+                 help="Use a database with automatic 'admin' user log in, for testing purposes only.")
+@optgroup.group("Logging", cls=OptionGroup)
+@optgroup.option(
+    "--log-level",
+    type=click.Choice(LOG_LEVELS, case_sensitive=False),
+    default=DEFAULT_LOG_LEVEL,
+    show_default=True,
+    help="Logging level.",
+)
+def main(fileset, file, metadata, db_user, db_password, no_auth, log_level):
+    """FSDB File Import CLI
 
+    A command‑line utility that imports a single file into a specified PlantDB fileset, optionally attaching
+    metadata and providing configurable logging.
 
-def main():
-    parser = parsing()
-    args = parser.parse_args()
+    FILESET is the path to the fileset that will receive the imported file.
+    FILE is the path to the source file you want to import.
+    """
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(log_level)
 
-    if args.metadata is not None:
-        metadata = json.loads(args.metadata)
-    else:
-        metadata = None
+    if not (no_auth or (db_user and db_password)):
+        raise click.UsageError("Requires using either the --no-auth flag or using both --user and --password")
 
-    fileset_dir = Path(args.fileset)
-    fileset_id = fileset_dir.name
-    file_id = Path(args.file).stem
-    scan_id = fileset_dir.parent
-    db_path = fileset_dir.parent.parent
+    # Load metadata if a path is provided
+    if metadata is not None:
+        with open(metadata, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
 
-    db = FSDB(db_path)
+    fileset_dir = Path(fileset)  # Directory representing the target fileset
+    fileset_id = fileset_dir.name  # Identifier derived from fileset folder name
+    file_id = Path(file).stem  # Identifier derived from source filename (without extension)
+    scan_id = fileset_dir.parent  # Parent directory used as scan identifier
+    db_path = fileset_dir.parent.parent  # Grandparent directory points to the database location
+
+    # Initialize the database
+    db = FSDB(db_path, no_auth=no_auth)
     db.connect()
 
+    # Authenticate unless explicitly disabled
+    if not no_auth and (db_user and db_password):
+        db.login(db_user, db_password)
+
     scan = db.create_scan(scan_id)
-    fileset = scan.create_fileset(fileset_id)
-    file = fileset.create_file(file_id)
-    file.import_file(args.file)
+    fileset_obj = scan.create_fileset(fileset_id)
+    file_obj = fileset_obj.create_file(file_id)
+    file_obj.import_file(file)
 
     if metadata is not None:
-        file.set_metadata(metadata)
+        file_obj.set_metadata(metadata)
 
     db.disconnect()
+
 
 if __name__ == '__main__':
     main()

--- a/src/commons/plantdb/commons/cli/fsdb_import_folder.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_folder.py
@@ -76,7 +76,7 @@ logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
     show_default=True,
     help="Logging level.",
 )
-def main(scan, folder, metadata, db_user, db_password, no_auth, log_level):
+def main(scan, folder, metadata, user, password, no_auth, log_level):
     """FSDB Folder Import CLI
 
     A command‑line utility that imports a folder's contents as a ``Fileset`` in a known ``Scan`` dataset, optionally
@@ -89,7 +89,7 @@ def main(scan, folder, metadata, db_user, db_password, no_auth, log_level):
     logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
     logger.setLevel(log_level)
 
-    if not (no_auth or (db_user and db_password)):
+    if not (no_auth or (user and password)):
         raise click.UsageError("Requires using either the --no-auth flag or using both --user and --password")
 
     # Load metadata if a path is provided
@@ -106,8 +106,8 @@ def main(scan, folder, metadata, db_user, db_password, no_auth, log_level):
     db.connect()
 
     # Authenticate unless explicitly disabled
-    if not no_auth and (db_user and db_password):
-        db.login(db_user, db_password)
+    if not no_auth and (user and password):
+        db.login(user, password)
 
     folder_path = Path(folder).resolve()
     fileset_id = folder_path.name

--- a/src/commons/plantdb/commons/cli/fsdb_import_folder.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_folder.py
@@ -53,7 +53,7 @@ logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.argument('scan', type=click.Path(exists=True))
+@click.argument('scan_path', type=click.Path(exists=True))
 @click.argument('folder', type=click.Path(exists=True))
 @click.option(
     '--metadata',
@@ -76,7 +76,7 @@ logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
     show_default=True,
     help="Logging level.",
 )
-def main(scan, folder, metadata, user, password, no_auth, log_level):
+def main(scan_path, folder, metadata, user, password, no_auth, log_level):
     """FSDB Folder Import CLI
 
     A command‑line utility that imports a folder's contents as a ``Fileset`` in a known ``Scan`` dataset, optionally
@@ -97,7 +97,7 @@ def main(scan, folder, metadata, user, password, no_auth, log_level):
         with open(metadata, "r", encoding="utf-8") as f:
             metadata = json.load(f)
 
-    scan_path = Path(scan)
+    scan_path = Path(scan_path)
     scan_id = scan_path.name
     db_path = scan_path.parent
 
@@ -112,14 +112,14 @@ def main(scan, folder, metadata, user, password, no_auth, log_level):
     folder_path = Path(folder).resolve()
     fileset_id = folder_path.name
 
-    fileset = scan.create_fileset(fileset_id)
+    fileset = scan_path.create_fileset(fileset_id)
     try:
         for f in os.listdir(folder_path):
             if os.path.isfile(os.path.join(folder_path, f)):
                 fi = fileset.create_file(os.path.splitext(f)[0])
                 fi.import_file(os.path.join(folder_path, f))
     except Exception as e:
-        scan.delete_fileset(fileset_id)
+        scan_path.delete_fileset(fileset_id)
         raise e
 
     if metadata is not None:

--- a/src/commons/plantdb/commons/cli/fsdb_import_folder.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_folder.py
@@ -2,49 +2,115 @@
 # -*- coding: utf-8 -*-
 
 """
-Import a folder as a ``Fileset`` in a known ``Scan``.
+# FSDB Folder Import CLI
+
+A command‑line utility that imports a folder's contents as a ``Fileset`` in a known ``Scan`` dataset, optionally
+attaching metadata and providing configurable logging.
+It streamlines adding new data to a PlantDB database directly from the terminal.
+
+## Key Features
+
+- **Simple CLI interface** using `click` with positional arguments for the target scan and source folder.
+- **Optional metadata**: load a JSON file and associate its contents with the imported fileset.
+- **Configurable logging**: choose from predefined log levels to control output verbosity.
+- **Automatic database handling**: connects to the FSDB, creates the necessary scan/fileset hierarchy, imports the files, applies metadata, and cleanly disconnects.
+- **Login support**: authenticate with username/password or use no-auth for testing.
+
+## Usage Examples
+
+### Basic import of a folder into an existing scan
+
+```shell
+fsdb_import_folder /romi_db/scan001 /path/to/folder_with_files
+```
+
+### Import with metadata and verbose logging
+
+```shell
+fsdb_import_folder /romi_db/scan001 /path/to/folder_with_files \
+    --metadata /path/to/folder_meta.json \
+    --log-level INFO
+```
+
 """
-import argparse
+
 import json
 import os
 from pathlib import Path
 
+import click
+from click_option_group import OptionGroup
+from click_option_group import optgroup
+
 from plantdb.commons.fsdb.core import FSDB
+from plantdb.commons.log import DEFAULT_LOG_LEVEL
+from plantdb.commons.log import LOG_LEVELS
+from plantdb.commons.log import get_logger
+
+# Create a logger and set the environment variable
+os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 
-def parsing():
-    parser = argparse.ArgumentParser(description="Import a folder as a ``Fileset`` in a known ``Scan``.")
-    parser.add_argument("folder", type=str,
-                        help="Folder to add to scan. Folder name will be the fileset id.")
-    parser.add_argument('--metadata', metavar='metadata', type=str, default=None,
-                        help="JSON or TOML file with metadata.")
-    parser.add_argument('--scan', type=str,
-                        help="Name of the scan dataset where to import the fileset to.")
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.argument('scan', type=click.Path(exists=True))
+@click.argument('folder', type=click.Path(exists=True))
+@click.option(
+    '--metadata',
+    type=click.Path(exists=True),
+    default=None,
+    help='Path to a JSON file with fileset related metadata.'
+)
+@optgroup.group("Login", cls=OptionGroup)
+@optgroup.option('-u', '--user', type=str, default=None,
+                 help="Username for FSDB login.")
+@optgroup.option('-p', '--password', type=str, default=None,
+                 help="Password for FSDB login.")
+@optgroup.option('--no-auth', is_flag=True, default=False,
+                 help="Use a database with automatic 'admin' user log in, for testing purposes only.")
+@optgroup.group("Logging", cls=OptionGroup)
+@optgroup.option(
+    "--log-level",
+    type=click.Choice(LOG_LEVELS, case_sensitive=False),
+    default=DEFAULT_LOG_LEVEL,
+    show_default=True,
+    help="Logging level.",
+)
+def main(scan, folder, metadata, db_user, db_password, no_auth, log_level):
+    """FSDB Folder Import CLI
 
-    return parser
+    A command‑line utility that imports a folder's contents as a ``Fileset`` in a known ``Scan`` dataset, optionally
+    attaching metadata and providing configurable logging.
 
+    SCAN is the path to the scan that will receive the imported fileset.
+    FOLDER is the path to the source folder containing files to import.
+    """
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(log_level)
 
-def main():
-    parser = parsing()
-    args = parser.parse_args()
-    if args.metadata is not None:
-        with open(args.metadata) as json_file:
-            metadata = json.load(json_file)
-    else:
-        metadata = None
+    if not (no_auth or (db_user and db_password)):
+        raise click.UsageError("Requires using either the --no-auth flag or using both --user and --password")
 
-    scan_path = Path(args.scan)
-    scan_id = os.path.basename(scan_path)
+    # Load metadata if a path is provided
+    if metadata is not None:
+        with open(metadata, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+
+    scan_path = Path(scan)
+    scan_id = scan_path.name
     db_path = scan_path.parent
 
-    db = FSDB(db_path)
+    # Initialize the database
+    db = FSDB(db_path, no_auth=no_auth)
     db.connect()
 
-    scan = db.create_scan(scan_id)
+    # Authenticate unless explicitly disabled
+    if not no_auth and (db_user and db_password):
+        db.login(db_user, db_password)
 
-    folder_path = args.folder.rstrip('/')
-    path = folder_path.split('/')
-    fileset_id = path[-1]
+    folder_path = Path(folder).resolve()
+    fileset_id = folder_path.name
 
     fileset = scan.create_fileset(fileset_id)
     try:
@@ -52,11 +118,15 @@ def main():
             if os.path.isfile(os.path.join(folder_path, f)):
                 fi = fileset.create_file(os.path.splitext(f)[0])
                 fi.import_file(os.path.join(folder_path, f))
-    except:
+    except Exception as e:
         scan.delete_fileset(fileset_id)
+        raise e
 
     if metadata is not None:
         fileset.set_metadata(metadata)
+
+    db.disconnect()
+
 
 if __name__ == '__main__':
     main()

--- a/src/commons/plantdb/commons/cli/fsdb_import_images.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_images.py
@@ -44,19 +44,17 @@ import click
 from click_option_group import OptionGroup
 from click_option_group import optgroup
 
-from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.log import DEFAULT_LOG_LEVEL
 from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
-DESC = """
-Import the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` dataset.
-"""
-IMG_EXT = [".png", ".jpg", ".jpeg"]
-
 # Create a logger and set the environment variable
 os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
+
+from plantdb.commons.fsdb.core import FSDB
+
+IMG_EXT = [".png", ".jpg", ".jpeg"]
 
 
 def list_image_files(images_path):
@@ -108,7 +106,7 @@ def load_metadata(md_path) -> dict:
     show_default=True,
     help="Logging level.",
 )
-def main(database, folder, name, metadata, db_user, db_password, no_auth, log_level):
+def main(database, folder, name, metadata, user, password, no_auth, log_level):
     """FSDB Images Import CLI
 
     A command‑line utility that imports the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` dataset,
@@ -121,7 +119,7 @@ def main(database, folder, name, metadata, db_user, db_password, no_auth, log_le
     logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
     logger.setLevel(log_level)
 
-    if not (no_auth or (db_user and db_password)):
+    if not (no_auth or (user and password)):
         raise click.UsageError("Requires using either the --no-auth flag or using both --user and --password")
 
     # - Configure a logger from this application:
@@ -145,8 +143,8 @@ def main(database, folder, name, metadata, db_user, db_password, no_auth, log_le
     db.connect()
 
     # - Authenticate unless explicitly disabled
-    if not no_auth and (db_user and db_password):
-        db.login(db_user, db_password)
+    if not no_auth and (user and password):
+        db.login(user, password)
 
     # - Defines the scan dataset name to create
     default_scan_name = folder_path.name
@@ -159,7 +157,6 @@ def main(database, folder, name, metadata, db_user, db_password, no_auth, log_le
     scan = db.create_scan(ds_name)
 
     # - Try to load metadata:
-    metadata = None
     if metadata is None:
         md_path = folder_path / "metadata.json"
         if md_path.exists():

--- a/src/commons/plantdb/commons/cli/fsdb_import_images.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_images.py
@@ -2,11 +2,47 @@
 # -*- coding: utf-8 -*-
 
 """
-Import the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` dataset.
+# FSDB Images Import CLI
+
+A command‑line utility that imports the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` dataset
+ optionally attaching metadata and providing configurable logging.
+ It streamlines adding new image data to a PlantDB database directly from the terminal.
+
+## Key Features
+
+- **Simple CLI interface** using `click` with positional arguments for the target database and source folder.
+- **Automatic scan creation**: Creates a new scan dataset with the folder name or a custom name.
+- **Image filtering**: Automatically filters for common image file extensions (.png, .jpg, .jpeg).
+- **Optional metadata**: load a JSON file and associate its contents with the imported fileset.
+- **Configurable logging**: choose from predefined log levels to control output verbosity.
+- **Automatic database handling**: connects to the FSDB, creates the necessary scan/fileset hierarchy, imports the files, applies metadata, and cleanly disconnects.
+- **Login support**: authenticate with username/password or use no-auth for testing.
+
+## Usage Examples
+
+### Basic import of images from a folder to a new scan
+
+```shell
+fsdb_import_images /romi_db /path/to/folder_with_images
+```
+
+### Import with custom scan name and verbose logging
+
+```shell
+fsdb_import_images /romi_db /path/to/folder_with_images \
+    --name my_custom_scan \
+    --log-level INFO
+```
+
 """
-import argparse
+
 import json
+import os
 from pathlib import Path
+
+import click
+from click_option_group import OptionGroup
+from click_option_group import optgroup
 
 from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.log import DEFAULT_LOG_LEVEL
@@ -18,27 +54,9 @@ Import the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` data
 """
 IMG_EXT = [".png", ".jpg", ".jpeg"]
 
-
-def parsing():
-    parser = argparse.ArgumentParser(description=DESC)
-    parser.add_argument("database", type=str,
-                        help="Local database where to create the scan dataset.")
-    parser.add_argument("folder", type=str,
-                        help="Folder containing the images to import.")
-
-    db_opt = parser.add_argument_group("Database options")
-    db_opt.add_argument("--name", type=str, default="",
-                        help="Name of the scan dataset where to import the fileset to. "
-                             "Defaults to the folder name")
-    db_opt.add_argument("--metadata", type=str, default=None,
-                        help="JSON or TOML file with metadata. "
-                             "Defaults to `metadata.json`")
-
-    log_opt = parser.add_argument_group("Logging options")
-    log_opt.add_argument("--log-level", dest="log_level", type=str, default=DEFAULT_LOG_LEVEL, choices=LOG_LEVELS,
-                         help="Level of message logging, defaults to 'INFO'.")
-
-    return parser
+# Create a logger and set the environment variable
+os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 
 def list_image_files(images_path):
@@ -63,14 +81,51 @@ def load_metadata(md_path) -> dict:
     return metadata
 
 
-def main():
-    # - Parse the input arguments to variables:
-    parser = parsing()
-    args = parser.parse_args()
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.argument('database', type=click.Path(exists=True))
+@click.argument('folder', type=click.Path(exists=True))
+@click.option('--name', type=str, default="",
+              help="Name of the scan dataset where to import the fileset to. "
+                   "Defaults to the folder name")
+@click.option(
+    '--metadata',
+    type=click.Path(exists=True),
+    default=None,
+    help='Path to a JSON file with fileset related metadata.'
+)
+@optgroup.group("Login", cls=OptionGroup)
+@optgroup.option('-u', '--user', type=str, default=None,
+                 help="Username for FSDB login.")
+@optgroup.option('-p', '--password', type=str, default=None,
+                 help="Password for FSDB login.")
+@optgroup.option('--no-auth', is_flag=True, default=False,
+                 help="Use a database with automatic 'admin' user log in, for testing purposes only.")
+@optgroup.group("Logging", cls=OptionGroup)
+@optgroup.option(
+    "--log-level",
+    type=click.Choice(LOG_LEVELS, case_sensitive=False),
+    default=DEFAULT_LOG_LEVEL,
+    show_default=True,
+    help="Logging level.",
+)
+def main(database, folder, name, metadata, db_user, db_password, no_auth, log_level):
+    """FSDB Images Import CLI
+
+    A command‑line utility that imports the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` dataset,
+    optionally attaching metadata and providing configurable logging.
+
+    DATABASE is the path to the local database where to create the scan dataset.
+    FOLDER is the path to the folder containing the images to import.
+    """
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(log_level)
+
+    if not (no_auth or (db_user and db_password)):
+        raise click.UsageError("Requires using either the --no-auth flag or using both --user and --password")
 
     # - Configure a logger from this application:
-    logger = get_logger('fsdb_import_folder', log_level=args.log_level)
-    folder_path = Path(args.folder).resolve()
+    folder_path = Path(folder).resolve()
     if not folder_path.exists():
         raise FileNotFoundError(f"{folder_path} do not exist!")
     if not folder_path.is_dir():
@@ -81,33 +136,36 @@ def main():
     try:
         assert len(img_files) != 0
     except AssertionError:
-        logger.error(f"No image found in folder '{args.folder}'!")
+        logger.error(f"No image found in folder '{folder}'!")
     else:
-        logger.info(f"Found {len(img_files)} image files in folder '{args.folder}'.")
+        logger.info(f"Found {len(img_files)} image files in folder '{folder}'.")
 
     # - Connect to the database:
-    db = FSDB(args.database)
+    db = FSDB(database, no_auth=no_auth)
     db.connect()
+
+    # - Authenticate unless explicitly disabled
+    if not no_auth and (db_user and db_password):
+        db.login(db_user, db_password)
 
     # - Defines the scan dataset name to create
     default_scan_name = folder_path.name
-    if args.name != "":
-        ds_name = Path(args.name).stem
+    if name != "":
+        ds_name = Path(name).stem
     else:
         ds_name = default_scan_name
 
     # - Create the scan dataset:
-    db.login("admin", "admin")
     scan = db.create_scan(ds_name)
 
     # - Try to load metadata:
     metadata = None
-    if args.metadata is None:
+    if metadata is None:
         md_path = folder_path / "metadata.json"
         if md_path.exists():
             metadata = load_metadata(md_path)
     else:
-        metadata = load_metadata(Path(args.metadata))
+        metadata = load_metadata(Path(metadata))
 
     # - Create & populate the 'images' fileset:
     fileset = scan.create_fileset('images')
@@ -115,8 +173,9 @@ def main():
         for f in img_files:
             fi = fileset.create_file(f.stem)
             fi.import_file(f.absolute())
-    except:
+    except Exception as e:
         scan.delete_fileset(fileset.id)
+        raise e
 
     # - Add the metadata to the 'images' fileset:
     if metadata is not None:

--- a/src/commons/plantdb/commons/cli/fsdb_import_images.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_images.py
@@ -80,7 +80,7 @@ def load_metadata(md_path) -> dict:
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.argument('database', type=click.Path(exists=True))
+@click.argument('db_path', type=click.Path(exists=True))
 @click.argument('folder', type=click.Path(exists=True))
 @click.option('--name', type=str, default="",
               help="Name of the scan dataset where to import the fileset to. "
@@ -106,7 +106,7 @@ def load_metadata(md_path) -> dict:
     show_default=True,
     help="Logging level.",
 )
-def main(database, folder, name, metadata, user, password, no_auth, log_level):
+def main(db_path, folder, name, metadata, user, password, no_auth, log_level):
     """FSDB Images Import CLI
 
     A command‑line utility that imports the content of a folder as an 'images' ``Fileset`` to a new ``Scan`` dataset,
@@ -139,7 +139,7 @@ def main(database, folder, name, metadata, user, password, no_auth, log_level):
         logger.info(f"Found {len(img_files)} image files in folder '{folder}'.")
 
     # - Connect to the database:
-    db = FSDB(database, no_auth=no_auth)
+    db = FSDB(db_path, no_auth=no_auth)
     db.connect()
 
     # - Authenticate unless explicitly disabled

--- a/src/commons/plantdb/commons/cli/shared_fsdb.py
+++ b/src/commons/plantdb/commons/cli/shared_fsdb.py
@@ -1,34 +1,41 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""Create a local plantdb database (FSDB) using shared datasets.
+"""
+# Shared FSDB Setup CLI
 
-This module provides a command-line interface for setting up a local plantdb database by cloning shared datasets.
-It is useful for users who need to work with specific test datasets without downloading them individually.
+A command‑line utility for setting up a local plantdb database (FSDB) by cloning shared datasets. It is useful for users who need to work with specific test datasets without downloading them individually.
 
-Key Features
-------------
+## Key Features
 
-- Supports cloning of multiple datasets, including all available ones or a specified subset.
-- Optional flags to clone configuration files and trained CNN model files.
-- Force download option to refresh the archive regardless of existing data.
-- Configurable logging levels for tracking setup progress and debugging.
+- **Simple CLI interface** using `click` with positional arguments for the target path.
+- **Dataset selection**: Supports cloning of multiple datasets, including all available ones or a specified subset.
+- **Optional data cloning**: Clone configuration files and trained CNN model files.
+- **Force download option**: Refresh the archive regardless of existing data.
+- **Configurable logging**: choose from predefined log levels to control output verbosity.
 
-Usage
------
+## Usage Examples
 
 To create a local database with the default 'real_plant' dataset at `/path/to/db`:
 
-.. code-block:: bash
-   $ shared_fsdb /path/to/db
+```shell
+shared_fsdb /path/to/db
+```
 
 To clone all available datasets along with configuration files to `/path/to/db`:
 
-.. code-block:: bash
-   $ shared_fsdb --dataset all --config /path/to/db
+```shell
+shared_fsdb --dataset all --config /path/to/db
+```
+
 """
 
-import argparse
+import os
+from pathlib import Path
+
+import click
+from click_option_group import OptionGroup
+from click_option_group import optgroup
 
 from plantdb.commons.log import DEFAULT_LOG_LEVEL
 from plantdb.commons.log import LOG_LEVELS
@@ -36,67 +43,66 @@ from plantdb.commons.log import get_logger
 from plantdb.commons.test_database import DATASET
 from plantdb.commons.test_database import setup_test_database
 
-
-def parsing():
-    # Create argument parser for command-line arguments
-    parser = argparse.ArgumentParser(description='Create a local plantdb database (FSDB) using shared datasets.')
-
-    # Define required 'path' argument - path to test database
-    parser.add_argument('path', type=str,
-                        help='Path to the test database to set up.')
-
-    # Define optional flags for configuration, models, and force download
-    parser.add_argument('-d', '--dataset', type=str, nargs="+",
-                        default=['real_plant'],
-                        help="Test dataset to clone, use 'all' to get all of them. " + \
-                             "You can list several dataset names to clone. " + \
-                             "Available dataset names are: " + \
-                             ", ".join([f"'{ds}'" for ds in DATASET]) + ". " + \
-                             "By default we clone the 'real_plant' dataset.")
-
-    # Define optional flags for configuration, models, and force download
-    parser.add_argument('--config', action='store_true',
-                        help='Use this to also clone the configuration files.')
-    parser.add_argument('--models', action='store_true',
-                        help='Use this to also clone the trained CNN model files.')
-    parser.add_argument('--force', action='store_true',
-                        help='Use this to force download of archive.')
-
-    log_opt = parser.add_argument_group("Logging options")
-    log_opt.add_argument("--log-level", dest="log_level", type=str, default=DEFAULT_LOG_LEVEL, choices=LOG_LEVELS,
-                         help="Level of message logging, defaults to 'INFO'.")
-    return parser
+# Create a logger and set the environment variable
+os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 
-def main():
-    # Initialize argument parser and parse arguments
-    parser = parsing()
-    args = parser.parse_args()
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.argument('path', type=click.Path())
+@click.option('-d', '--dataset', type=str, nargs="+",
+              default=['real_plant'],
+              help="Test dataset to clone, use 'all' to get all of them. " +
+                   "You can list several dataset names to clone. " +
+                   "Available dataset names are: " +
+                   ", ".join([f"'{ds}'" for ds in DATASET]) + ". " +
+                   "By default we clone the 'real_plant' dataset.")
+@click.option('--config', is_flag=True,
+              help='Use this to also clone the configuration files.')
+@click.option('--models', is_flag=True,
+              help='Use this to also clone the trained CNN model files.')
+@click.option('--force', is_flag=True,
+              help='Use this to force download of archive.')
+@optgroup.group("Logging", cls=OptionGroup)
+@optgroup.option(
+    "--log-level",
+    type=click.Choice(LOG_LEVELS, case_sensitive=False),
+    default=DEFAULT_LOG_LEVEL,
+    show_default=True,
+    help="Logging level.",
+)
+def main(path, dataset, config, models, force, log_level):
+    """Shared FSDB Setup CLI
 
-    # Set up logger with the specified log level from arguments
-    logger = get_logger(__name__, log_level=args.log_level)
+    A command‑line utility for setting up a local plantdb database (FSDB) by cloning shared datasets.
+
+    PATH is the path to the test database to set up.
+    """
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
+    logger.setLevel(log_level)
 
     # If "all" is in dataset, replace it with all available datasets
-    if args.dataset[0] == "all":
-        args.dataset = DATASET
+    if dataset[0] == "all":
+        dataset = DATASET
 
     # Validate and filter requested datasets to ensure they exist
-    args.dataset = list(set(args.dataset) & set(DATASET))
+    dataset = list(set(dataset) & set(DATASET))
 
     # Log critical error and raise ValueError if no valid dataset names are provided
-    if len(args.dataset) == 0:
+    if len(dataset) == 0:
         logger.critical(f"No valid dataset name defined, select among {' ,'.join(DATASET)}.")
         raise ValueError("No valid dataset name defined!")
 
-    # Setup test database with the validated datasets and specified options
-    out_path = setup_test_database(args.dataset,
-                                   db_path=args.path,
-                                   with_configs=args.config,
-                                   with_models=args.models,
-                                   force=args.force)
+    # Set up test database with the validated datasets and specified options
+    out_path = setup_test_database(dataset,
+                                   db_path=path,
+                                   with_configs=config,
+                                   with_models=models,
+                                   force=force)
 
     # Log success message indicating completion of dataset cloning
-    logger.info(f"Done cloning dataset{'s' if len(args.dataset) > 1 else ''}: {', '.join(args.dataset)}.")
+    logger.info(f"Done cloning dataset{'s' if len(dataset) > 1 else ''}: {', '.join(dataset)}.")
 
 
 if __name__ == "__main__":

--- a/src/commons/plantdb/commons/log.py
+++ b/src/commons/plantdb/commons/log.py
@@ -22,7 +22,56 @@
 # License along with plantdb.  If not, see
 # <https://www.gnu.org/licenses/>.
 # ------------------------------------------------------------------------------
+
+"""Logging Configuration and Management
+
+A comprehensive logging utility module that provides flexible and configurable logging setup
+for Python applications, supporting both console and file-based logging with color formatting options.
+
+Environment Variable
+--------------------
+``ROMI_APP_LOGGER`` is an optional environment variable that can be used to override the default logger name.
+When ``ROMI_APP_LOGGER`` is defined, the ``get_logger`` function will use its value as the logger name instead
+of the module‑derived name. This allows a single logger configuration to be shared across multiple components
+of the ROMI application.
+
+Key Features
+------------
+- Configurable log levels with sensible defaults
+- Console logging with optional color formatting
+- File-based logging with automatic file handling
+- Dummy logger for testing/development
+- Centralized logging configuration management
+- Custom formatting options for log messages
+- Dynamic log filename generation
+
+Usage Examples
+--------------
+>>> # Basic usage
+>>> from plantdb.log import get_logger
+>>> logger = get_logger(__name__)
+>>> logger.info("Application started")
+INFO     [__main__] Application started
+>>> logger.error("An error occurred")
+ERROR    [__main__] An error occurred
+
+>>> # With custom configuration
+>>> logger = get_logger(__name__, log_level="DEBUG")
+>>> logger.debug("Debugging information")
+DEBUG    [__main__] Debugging information
+
+>>> # With App logger
+>>> import os
+>>> logger = get_logger('MyApp', log_level="INFO")
+>>> os.environ.setdefault('ROMI_APP_LOGGER', 'fsdb_rest_api')
+>>> # Can be called by another module, the environment variable will override logger name
+>>> another_logger = get_logger('MyModule')
+>>> another_logger.info("Debugging information")
+INFO     [fsdb_rest_api] Debugging information
+"""
+
 import logging
+import os
 import sys
 
 from colorlog import ColoredFormatter
@@ -143,7 +192,8 @@ def get_logger(logger_name, log_file=None, log_level=DEFAULT_LOG_LEVEL):
     logging.Logger
         The configured logger instance ready to log messages with the specified settings.
     """
-    logger_name = logger_name.split(".")[-1]
+    name = logger_name.split(".")[-1]
+    logger_name = os.getenv('ROMI_APP_LOGGER', name)
     if not logging.getLogger(logger_name).hasHandlers():
         return _get_logger(logger_name, log_file=log_file, log_level=log_level)
     return logging.getLogger(logger_name)

--- a/src/commons/pyproject.toml
+++ b/src/commons/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "toml",
     "tqdm",
     "send2trash",
+    "click",
     "click_option_group"
 ]
 description = "Core shared library for the ROMI plant database ecosystem."

--- a/src/commons/tests/test_romi_import_images.py
+++ b/src/commons/tests/test_romi_import_images.py
@@ -33,19 +33,22 @@ class TestFSDBDummy(DummyDBTestCase):
         db._is_dummy = False  # to avoid clean up by 'disconnect' method
         db.disconnect()
         copy_path = TESTS_ROOT / "testdata" / "testscan" / "testfileset"
-        out = subprocess.run(["fsdb_import_images", str(db.path()), copy_path,
+        cmd = ["fsdb_import_images", str(db.path()), copy_path,
                               "--name", "test_import_img",
-                              "--metadata", TESTS_ROOT / "testdata" / "testscan" / "files.json"], capture_output=True)
+                              "--metadata", TESTS_ROOT / "testdata" / "testscan" / "files.json",
+                              "--no-auth"]
+        print("Calling: " + ' '.join(map(str, cmd)))
+        out = subprocess.run(cmd, capture_output=True)
         rcode = out.returncode
         if rcode != 0:
             print(f"Return code: {rcode}")
-            print(f"Captured stdout: {out.stdout}")
-            print(f"Captured stderr: {out.stderr}")
+            print(f"Captured stdout: {out.stdout.decode()}")
+            print(f"Captured stderr: {out.stderr.decode()}")
         self.assertTrue(rcode == 0, msg=f"Return code is {rcode}: {out.stderr}")
         db.connect()
         # Test database path:
         self.assertTrue(db.path().is_dir())
-        # Test scan exist and its path exists:
+        # Test that the scan exists and its path exists:
         scan = db.get_scan('test_import_img')
         self.assertIsNotNone(scan)
         self.assertTrue(scan.path().is_dir())

--- a/src/server/plantdb/server/cli/fsdb_rest_api.py
+++ b/src/server/plantdb/server/cli/fsdb_rest_api.py
@@ -88,16 +88,43 @@ from flask_restful import Api
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from plantdb.commons.log import get_logger
+from plantdb.commons.log import LOG_LEVELS
+from plantdb.commons.log import DEFAULT_LOG_LEVEL
 
 # Create a logger and set the environment variable
-logger = get_logger("fsdb_rest_api", log_level='INFO')
-os.environ.setdefault('ROMI_APP_LOGGER', 'fsdb_rest_api')
+os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
+from plantdb.commons.api_endpoints import API_PREFIX
+from plantdb.commons.api_endpoints import ARCHIVE
+from plantdb.commons.api_endpoints import CREATE_API_TOKEN
+from plantdb.commons.api_endpoints import FILE
+from plantdb.commons.api_endpoints import FILESET
+from plantdb.commons.api_endpoints import FILESET_FILES
+from plantdb.commons.api_endpoints import FILESET_MD
+from plantdb.commons.api_endpoints import FILE_MD
+from plantdb.commons.api_endpoints import FILE_PATH
+from plantdb.commons.api_endpoints import HEALTH
+from plantdb.commons.api_endpoints import HOME
+from plantdb.commons.api_endpoints import IMAGE
+from plantdb.commons.api_endpoints import LOGIN
+from plantdb.commons.api_endpoints import LOGOUT
+from plantdb.commons.api_endpoints import MESH
+from plantdb.commons.api_endpoints import POINTCLOUD
+from plantdb.commons.api_endpoints import REFRESH
+from plantdb.commons.api_endpoints import REGISTER
+from plantdb.commons.api_endpoints import SCAN
+from plantdb.commons.api_endpoints import SCANS
+from plantdb.commons.api_endpoints import SCANS_INFO
+from plantdb.commons.api_endpoints import SCAN_FILESETS
+from plantdb.commons.api_endpoints import SCAN_MD
+from plantdb.commons.api_endpoints import SEQUENCE
+from plantdb.commons.api_endpoints import SKELETON
+from plantdb.commons.api_endpoints import TOKEN_REFRESH
+from plantdb.commons.api_endpoints import TOKEN_VALIDATION
 from plantdb.commons.auth.session import JWTSessionManager
 from plantdb.commons.auth.session import _init_secret_key
 from plantdb.commons.fsdb.core import FSDB
-from plantdb.commons.log import DEFAULT_LOG_LEVEL
-from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.test_database import DATASET
 from plantdb.commons.test_database import test_database
 from plantdb.server.api.assets import Archive
@@ -373,7 +400,7 @@ def rest_api(
     """
     wlogger = logging.getLogger("werkzeug")
     # Get the logger and change the level if needed:
-    logger = get_logger(os.environ.get('ROMI_APP_LOGGER'))
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER', __name__))
     logger.setLevel(log_level)
 
     # 1 - Application and API configuration
@@ -502,7 +529,7 @@ def rest_api(
     help="Logging level.",
 )
 def main(host, port, debug, proxy, api_prefix, db_path, test, empty, models, log_level):
-    """Entry point for the REST API server using Click."""
+    """FSDB REST API - Serve Plant Database through RESTful Endpoints."""
     app = rest_api(db_path=db_path, proxy=proxy, api_prefix=api_prefix, log_level=log_level.upper(), test=test,
                    empty=empty, models=models)
     # Start the Flask development server.

--- a/src/server/plantdb/server/cli/fsdb_rest_api.py
+++ b/src/server/plantdb/server/cli/fsdb_rest_api.py
@@ -87,39 +87,17 @@ from flask_cors import CORS
 from flask_restful import Api
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from plantdb.commons.api_endpoints import API_PREFIX
-from plantdb.commons.api_endpoints import ARCHIVE
-from plantdb.commons.api_endpoints import CREATE_API_TOKEN
-from plantdb.commons.api_endpoints import FILE
-from plantdb.commons.api_endpoints import FILESET
-from plantdb.commons.api_endpoints import FILESET_FILES
-from plantdb.commons.api_endpoints import FILESET_MD
-from plantdb.commons.api_endpoints import FILE_MD
-from plantdb.commons.api_endpoints import FILE_PATH
-from plantdb.commons.api_endpoints import HEALTH
-from plantdb.commons.api_endpoints import HOME
-from plantdb.commons.api_endpoints import IMAGE
-from plantdb.commons.api_endpoints import LOGIN
-from plantdb.commons.api_endpoints import LOGOUT
-from plantdb.commons.api_endpoints import MESH
-from plantdb.commons.api_endpoints import POINTCLOUD
-from plantdb.commons.api_endpoints import REFRESH
-from plantdb.commons.api_endpoints import REGISTER
-from plantdb.commons.api_endpoints import SCAN
-from plantdb.commons.api_endpoints import SCANS
-from plantdb.commons.api_endpoints import SCANS_INFO
-from plantdb.commons.api_endpoints import SCAN_FILESETS
-from plantdb.commons.api_endpoints import SCAN_MD
-from plantdb.commons.api_endpoints import SEQUENCE
-from plantdb.commons.api_endpoints import SKELETON
-from plantdb.commons.api_endpoints import TOKEN_REFRESH
-from plantdb.commons.api_endpoints import TOKEN_VALIDATION
+from plantdb.commons.log import get_logger
+
+# Create a logger and set the environment variable
+logger = get_logger("fsdb_rest_api", log_level='INFO')
+os.environ.setdefault('ROMI_APP_LOGGER', 'fsdb_rest_api')
+
 from plantdb.commons.auth.session import JWTSessionManager
 from plantdb.commons.auth.session import _init_secret_key
 from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.log import DEFAULT_LOG_LEVEL
 from plantdb.commons.log import LOG_LEVELS
-from plantdb.commons.log import get_logger
 from plantdb.commons.test_database import DATASET
 from plantdb.commons.test_database import test_database
 from plantdb.server.api.assets import Archive
@@ -394,7 +372,9 @@ def rest_api(
         Defaults to ``False``.
     """
     wlogger = logging.getLogger("werkzeug")
-    logger = get_logger("fsdb_rest_api", log_level=log_level)
+    # Get the logger and change the level if needed:
+    logger = get_logger(os.environ.get('ROMI_APP_LOGGER'))
+    logger.setLevel(log_level)
 
     # 1 - Application and API configuration
     secret_key = _get_env_secret("FLASK_SECRET_KEY", logger)

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -52,6 +52,7 @@ classifiers = [
 
 [project.scripts]
 fsdb_rest_api = "plantdb.server.cli.fsdb_rest_api:main"
+fsdb_healthcheck = "plantdb.comons.cli.fsdb_healthcheck:main"
 
 [project.urls]
 homepage = "https://romi-project.eu/"


### PR DESCRIPTION
This pull request migrates several command‑line tools in the PlantDB project from argparse to click, adds configurable logging, and improves logger handling across modules. It also updates documentation strings, refactors imports, and introduces environment‑variable based logger naming.

- Replaces `argparse` with `click` for CLI parsing in sync, health‑check, file/folder/image import, and shared FSDB setup scripts.
- Adds `--log-level` options and uses `plantdb.commons.log.get_logger` with environment variable `ROMI_APP_LOGGER` for consistent logger names.
- Refactors logger creation: sets default logger name, ensures proper log level assignment, and removes duplicated logger definitions.
- Updates usage examples and docstrings to reflect the new CLI interface.
- Minor function signature changes (_e.g._, `request_archive_download` and `request_archive_upload` argument order).
- Fixes import ordering and removes unused imports.
- Adjusts test command to include `--no-auth` flag for the new authentication handling.
- Adds missing logger import and configuration in the REST API server script.
- Minor typo correction in `pyproject.toml` script entry.