### PR TITLE
Add TOML configuration API to Scan

### DIFF
--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -1970,6 +1970,9 @@ class Scan(db.Scan, MetadataManager):
         The identifier of this ``Scan`` instance in the local database `db`.
     metadata : dict
         A metadata dictionary.
+    configs : dict
+        A dictionary listing the paths to the TOML configuration files.
+        Indexed by configuration file stem, typically `'scan'` or `'pipeline'`.
     filesets : dict[str, plantdb.commons.fsdb.core.Fileset]
         A dictionary of `Fileset` instances, indexed by their identifier.
 

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -138,6 +138,7 @@ import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 from shutil import copyfile
+from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
@@ -2241,6 +2242,48 @@ class Scan(db.Scan, MetadataManager):
     @get_authentication
     @use_guest_as_default
     @requires_permission(Permission.READ, check_scan_access=True)
+    def get_configuration(self, key, current_user=None, **kwargs) -> dict[str, Any]:
+        """Get the configurations associated with a scan.
+
+        Parameters
+        ----------
+        key : str
+            The scan's configuration name to recover, usually `'scan'` or `'pipeline'`.
+
+        Returns
+        -------
+        dict
+            The configuration dictionary.
+
+        Examples
+        --------
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database(no_auth=True)
+        >>> db.connect()
+        >>> scan = db.get_scan('real_plant_analyzed')
+        >>> # Get the scan configuration
+        >>> scan_cfg = scan.get_configuration('scan')
+        >>> print(scan_cfg['ScanPath']['class_name'])
+        Circle
+        >>> # Get the reconstruction pipeline configuration:
+        >>> pipe_cfg = scan.get_configuration('pipeline')
+        >>> print(pipe_cfg['PointCloud'])
+        {'upstream_task': 'Voxels', 'level_set_value': 1.0}
+        >>> db.disconnect()
+        """
+        from plantdb.commons.io import read_toml
+        if key not in self.configs:
+            self.logger.warning(f"No configuration found for {key}.")
+            return {}
+
+        # Use shared lock for read operations
+        with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username, LockLevel.SCAN):
+            cfg_path = self.configs[key]
+            return read_toml(cfg_path)
+
+    @get_authentication
+    @use_guest_as_default
+    @requires_permission(Permission.READ, check_scan_access=True)
     def get_measures(self, key=None, current_user=None, **kwargs):
         """Get the manual measurements associated with a scan.
 
@@ -2259,6 +2302,19 @@ class Scan(db.Scan, MetadataManager):
         -----
         These manual measurements should be a JSON file named `measures.json`.
         It is located at the root folder of the scan dataset.
+
+        Examples
+        --------
+        >>> from plantdb.commons.test_database import test_database
+        >>> db = test_database(no_auth=True)
+        >>> db.connect()
+        >>> scan = db.get_scan('real_plant_analyzed')
+        >>> measures = scan.get_measures()
+        >>> print(list(measures.keys()))
+        ['angles', 'internodes']
+        >>> print(measures['angles'][:3])  # print the first 3 measures angles
+        [2.356194490192345, 0.9599310885968813, 2.1816615649929116]
+        >>> db.disconnect()
         """
         # Use shared lock for read operations
         with self.db.lock_manager.acquire_lock(self.id, LockType.SHARED, current_user.username, LockLevel.SCAN):

--- a/src/commons/plantdb/commons/fsdb/core.py
+++ b/src/commons/plantdb/commons/fsdb/core.py
@@ -2052,6 +2052,7 @@ class Scan(db.Scan, MetadataManager):
         # Defines attributes:
         self.metadata = {}
         self.filesets = {}
+        self.configs = {}
         self.measures = None
 
         self.session_manager = self.db.session_manager

--- a/src/commons/plantdb/commons/fsdb/file_ops.py
+++ b/src/commons/plantdb/commons/fsdb/file_ops.py
@@ -228,6 +228,8 @@ def _load_scan(db: 'FSDB', scan_id: str, updates_files_json: bool = False) -> 'S
             _store_scan(scan)  # update the scan's ``files.json``
         # Try to load the scan's metadata
         scan.metadata = _load_scan_metadata(scan)
+        # Try to list the scan's configs
+        scan.configs = _list_scan_configs(scan)
         # Try to load the scan's manual measure, if any
         scan.measures = _load_scan_measures(scan)
     else:
@@ -493,6 +495,51 @@ def _load_file(fileset: 'Fileset', file_info: dict[str, str]) -> 'File':
     file = _parse_file(fileset, file_info)
     file.metadata = _load_file_metadata(file)
     return file
+
+
+def _list_scan_configs(scan:'Scan') -> dict[str, Path]:
+    """List path to all TOML configuration files associated with a scan.
+
+    This helper iterates over every ``*.toml`` file located in the supplied *scan* directory.
+    Each file location and stored in a dictionary keyed by the file stem.
+
+    Parameters
+    ----------
+    scan : plantdb.commons.fsdb.core.Scan
+        The instance to use to list the configuration files.
+
+    Returns
+    -------
+    dict[str, pathlib.Path]
+        Mapping from the stem of each TOML file to the parsed configuration dictionary.
+        If a file could not be read, the value will be ``None``.
+
+    See Also
+    --------
+    _scan_path : Resolve a scan identifier to a filesystem path.
+
+    Examples
+    --------
+    >>> from plantdb.commons.test_database import test_database
+    >>> from plantdb.commons.fsdb.core import Scan
+    >>> from plantdb.commons.fsdb.file_ops import _list_scan_configs
+    >>> db = test_database(no_auth=True)
+    >>> db.connect()
+    >>> scan = Scan(db, 'real_plant_analyzed')
+    >>> configs = _list_scan_configs(scan)
+    >>> sorted(configs.keys())
+    ['pipeline', 'scan']
+    >>> print(configs['scan'])
+    PosixPath('/tmp/ROMI_DB_hicfekb9/real_plant_analyzed/scan.toml')
+    """
+    path = _scan_path(scan)
+    toml_files = path.glob("*.toml")
+
+    configs = {}
+    for toml_file in toml_files:
+        configs[toml_file.stem] = toml_file
+
+    return configs
 
 
 def _load_measures(path: str | Path) -> dict[str, Any]:


### PR DESCRIPTION
Implemented full TOML configuration support for scans:

- Added `configs` attribute to `Scan` objects and populated it during scan loading.
- Created `_list_scan_configs` helper to discover `*.toml` files in a scan directory and map stems to file paths.
- Updated the scan loading sequence to include configuration discovery alongside metadata and measures.
- Introduced `get_configuration(self, key, current_user=None, **kwargs) -> dict[str, Any]`:
  - Performs authentication and permission checks.
  - Acquires a shared lock before reading.
  - Parses the requested TOML configuration file and returns its contents as a dictionary.
  - Includes extensive docstring with usage examples.