### PR TITLE
Add workspace metadata fallback & enhance legacy scans

### DIFF
--- a/src/commons/plantdb/commons/fsdb/metadata.py
+++ b/src/commons/plantdb/commons/fsdb/metadata.py
@@ -145,13 +145,15 @@ def _load_scan_metadata(scan: Scan) -> dict[str, Any]:
     md_path = _scan_metadata_path(scan)
     if md_path.exists():
         scan_md.update(_load_metadata(md_path))
-    # FIXME: next lines are here to solve the issue that most scans dataset have no metadata as they have been saved in the 'images' fileset metadata...
+
+    # FIXME: next lines are here to solve the issue that scans dataset prior to 2026 have no metadata as they have been saved in the 'images' fileset metadata...
     img_fs_path = md_path.parent / 'images.json'  # path to 'images' fileset metadata
     if img_fs_path.exists():
         img_fs_md = _load_metadata(img_fs_path)
-        scan_md.update({'object': img_fs_md.get('object', {})})
-        scan_md.update({'hardware': img_fs_md.get('hardware', {})})
-        scan_md.update({'acquisition_date': img_fs_md.get('acquisition_date', None)})
+        # Update the fields only if empty from the scan's metadata file
+        for md_key in ['object', 'hardware', 'acquisition_date']:
+            if scan_md[md_key] == {}:
+                scan_md.update({md_key: img_fs_md.get(md_key, {})})
     return scan_md
 
 

--- a/src/commons/plantdb/commons/fsdb/metadata.py
+++ b/src/commons/plantdb/commons/fsdb/metadata.py
@@ -152,7 +152,7 @@ def _load_scan_metadata(scan: Scan) -> dict[str, Any]:
         img_fs_md = _load_metadata(img_fs_path)
         # Update the fields only if empty from the scan's metadata file
         for md_key in ['object', 'hardware', 'acquisition_date']:
-            if scan_md[md_key] == {}:
+            if scan_md.get(md_key, {}) == {}:
                 scan_md.update({md_key: img_fs_md.get(md_key, {})})
     return scan_md
 

--- a/src/server/plantdb/server/services/scan.py
+++ b/src/server/plantdb/server/services/scan.py
@@ -181,8 +181,8 @@ def get_scan_info(scan, **kwargs):
             f = fs.get_file(task)
             scan_info["filesUri"][uri_key] = api_endpoints.file_path(f"{scan.id}/{fs.id}/{f.id}")
 
-    # Get the workspace metadata
-    scan_info["workspace"] = img_fs.get_metadata("workspace")
+    # Get the workspace metadata from the scan metadata, or fallback to image metadata (older implementation)
+    scan_info["workspace"] = scan_md.get('workspace', img_fs.get_metadata("workspace"))
     # Get the camera metadata
     scan_info["camera"] = {}
     if img_f.get_metadata("colmap_camera") != {}:


### PR DESCRIPTION
This pull request introduces two key improvements:

- **Workspace metadata fallback** – The scan reader now attempts to retrieve the `workspace` value from primary scan metadata first, falling back to `image_fs.get_metadata("workspace")` if missing.
- **Legacy scan handling** – For scans older than 2026, `object`, `hardware`, and `acquisition_date` are only populated when those fields are empty in the primary metadata. Existing values are preserved.

These changes enhance compatibility with older scans while maintaining accurate metadata extraction.