### PR TITLE
Refine logger naming

### DIFF
--- a/src/client/plantdb/client/cli/fsdb_rest_api_sync.py
+++ b/src/client/plantdb/client/cli/fsdb_rest_api_sync.py
@@ -80,7 +80,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 

--- a/src/commons/plantdb/commons/cli/fsdb_import_file.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_file.py
@@ -44,7 +44,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.fsdb.core import FSDB

--- a/src/commons/plantdb/commons/cli/fsdb_import_folder.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_folder.py
@@ -48,7 +48,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 

--- a/src/commons/plantdb/commons/cli/fsdb_import_images.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_images.py
@@ -49,7 +49,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.fsdb.core import FSDB

--- a/src/commons/plantdb/commons/cli/shared_fsdb.py
+++ b/src/commons/plantdb/commons/cli/shared_fsdb.py
@@ -44,7 +44,7 @@ from plantdb.commons.test_database import DATASET
 from plantdb.commons.test_database import setup_test_database
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 

--- a/src/server/plantdb/server/cli/fsdb_rest_api.py
+++ b/src/server/plantdb/server/cli/fsdb_rest_api.py
@@ -92,7 +92,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import DEFAULT_LOG_LEVEL
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __file__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.api_endpoints import API_PREFIX

--- a/src/server/plantdb/server/test_rest_api.py
+++ b/src/server/plantdb/server/test_rest_api.py
@@ -18,13 +18,17 @@ blocking the main interpreter, enabling fast, isolated integration tests.
 ## Usage Examples
 
 ```python
+>>> from plantdb.commons.test_database import test_database
 >>> from plantdb.server.test_rest_api import test_rest_api
->>> # Create a temporary test database and start the API
->>> api = test_rest_api()
+>>> from plantdb.server.test_rest_api import API_PREFIX
+>>> # Create a test database
+>>> db = test_database(dataset=None)
+>>> # Create and start a REST API server
+>>> api = test_rest_api(db.path(), port=5000)
 >>> api.start()
 >>> # Interact with the API (e.g., list scans)
 >>> import requests
->>> response = requests.get(f"{api.get_base_url()}/scans")
+>>> response = requests.get(f"{api.get_base_url()}/{API_PREFIX}/scans")
 >>> print(response.json())
 ['arabidopsis000', 'real_plant', 'real_plant_analyzed', 'virtual_plant', 'virtual_plant_analyzed']
 >>> api.stop()


### PR DESCRIPTION

- Modified logger initialization across several CLI modules to use `__name__` (or its components) rather than `__file__`, ensuring logger names match the module names for consistency.
- Updated REST API test examples to import `API_PREFIX` and `test_database`, create a temporary test database, and build request URLs using the prefix instead of hard‑coded paths.
- Adjusted example usage comments to reflect new imports and URL construction.