### PR TITLE
Add Plant Imager v3 support to REST API

### DIFF
--- a/src/server/plantdb/server/services/scan.py
+++ b/src/server/plantdb/server/services/scan.py
@@ -201,7 +201,7 @@ def get_scan_info(scan, **kwargs):
             z = min(scan.get_configuration("pipeline")["Voxels"]["bounding_box"]["z"])
         except:
             z = -750  # fallback value
-        scan_info["workspace"] = {"x": [x-150, x+150], "y": [y-150, y+150], "z": sorted([z-150, z+150])}
+        scan_info["workspace"] = {"x": [x-150, x+150], "y": [y-150, y+150], "z": [z-150, z+150]}
     else:
         # Get the workspace metadata from the scan metadata, or fallback to image metadata (older implementation)
         scan_info["workspace"] = scan_md.get('workspace', img_fs.get_metadata("workspace"))

--- a/src/server/plantdb/server/services/scan.py
+++ b/src/server/plantdb/server/services/scan.py
@@ -188,8 +188,24 @@ def get_scan_info(scan, **kwargs):
             f = fs.get_file(task)
             scan_info["filesUri"][uri_key] = api_endpoints.file_path(f"{scan.id}/{fs.id}/{f.id}")
 
-    # Get the workspace metadata from the scan metadata, or fallback to image metadata (older implementation)
-    scan_info["workspace"] = scan_md.get('workspace', img_fs.get_metadata("workspace"))
+    # In the P3DX, the 'workspace' is used to center the plant with:
+    # this.viewerObjects.position.x = -(workspace.x[1] - workspace.x[0])
+    # this.viewerObjects.position.y = -(workspace.y[1] - workspace.y[0])
+    # this.viewerObjects.position.z = workspace.z[1] - (workspace.z[1] - workspace.z[0])
+    # FIXME: Replace this with a XYZ 'position' parameter in future release.
+    if "ScanPath" in scan_md:
+        # Plant Imager v3 API
+        x = scan_md["ScanPath"]["kwargs"]["center_x"]
+        y = scan_md["ScanPath"]["kwargs"]["center_y"]
+        try:
+            z = min(scan.get_configuration("pipeline")["Voxels"]["bounding_box"]["z"])
+        except:
+            z = -750  # fallback value
+        scan_info["workspace"] = {"x": [x-150, x+150], "y": [y-150, y+150], "z": sorted([z-150, z+150])}
+    else:
+        # Get the workspace metadata from the scan metadata, or fallback to image metadata (older implementation)
+        scan_info["workspace"] = scan_md.get('workspace', img_fs.get_metadata("workspace"))
+
     # Get the camera metadata
     scan_info["camera"] = {}
     if img_f.get_metadata("colmap_camera") != {}:

--- a/src/server/plantdb/server/services/scan.py
+++ b/src/server/plantdb/server/services/scan.py
@@ -121,10 +121,17 @@ def get_scan_info(scan, **kwargs):
     ## Get acquisition date:
     scan_info["metadata"]['date'] = get_scan_date(scan)
     ## Import 'object' related scan metadata to scan info template:
-    if 'object' in scan_md:
+    if 'object' in scan_md and scan_md["object"]:
+        # Plant Imager v2 API
         scan_obj = scan_md['object']  # get the 'object' related dictionary
         scan_info["metadata"]["species"] = scan_obj.get('species', 'N/A')
         scan_info["metadata"]["environment"] = scan_obj.get('environment', 'N/A')
+        scan_info["metadata"]["plant"] = scan_obj.get('plant_id', 'N/A')
+    else:
+        # Plant Imager v3 API
+        scan_obj = scan_md.get('Metadata', {'object':{}}).get('object', {})  # get the 'object' related dictionary
+        scan_info["metadata"]["species"] = scan_obj.get('species', 'N/A')
+        scan_info["metadata"]["environment"] = scan_obj.get('growth_environment', 'N/A')
         scan_info["metadata"]["plant"] = scan_obj.get('plant_id', 'N/A')
     ## Get the number of 'images' in the dataset:
     scan_info["metadata"]['nbPhotos'] = len(scan_info["images"])


### PR DESCRIPTION
- Detect `ScanPath` in `scan_md` and compute a workspace range (`x`, `y`, `z`) using the scan center and pipeline bounding box (fallback `z = -750`).  
- Populate `scan_info["workspace"]` with offsets around the computed center coordinates.  
- Preserve existing fallback to `scan_md['workspace']` or image metadata when `ScanPath` is missing.  
- Extend metadata handling to support Plant Imager **v3** API: read object data from `scan_md['Metadata']['object']`, map `growth_environment` to the `environment` key, and ensure `plant_id` is stored under `plant`.  
- Keep existing Plant Imager **v2** handling (`'object'` field) for backward compatibility.  
- Added comprehensive inline comments and a `FIXME` note for future `position` parameter handling.