### PR TITLE
Standardize CLI logger names

### DIFF
--- a/src/client/plantdb/client/cli/fsdb_rest_api_sync.py
+++ b/src/client/plantdb/client/cli/fsdb_rest_api_sync.py
@@ -80,7 +80,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 

--- a/src/commons/plantdb/commons/cli/fsdb_healthcheck.py
+++ b/src/commons/plantdb/commons/cli/fsdb_healthcheck.py
@@ -43,8 +43,8 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import DEFAULT_LOG_LEVEL
 
 # Create a logger and set the environment variable
-logger = get_logger("fsdb_rest_api", log_level=DEFAULT_LOG_LEVEL)
-os.environ.setdefault('ROMI_APP_LOGGER', 'fsdb_rest_api')
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
+logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.fsdb.core import FSDB
 from plantdb.commons.fsdb.core import MARKER_FILE_NAME

--- a/src/commons/plantdb/commons/cli/fsdb_import_file.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_file.py
@@ -44,7 +44,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.fsdb.core import FSDB

--- a/src/commons/plantdb/commons/cli/fsdb_import_folder.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_folder.py
@@ -48,7 +48,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 

--- a/src/commons/plantdb/commons/cli/fsdb_import_images.py
+++ b/src/commons/plantdb/commons/cli/fsdb_import_images.py
@@ -49,7 +49,7 @@ from plantdb.commons.log import LOG_LEVELS
 from plantdb.commons.log import get_logger
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 from plantdb.commons.fsdb.core import FSDB

--- a/src/commons/plantdb/commons/cli/shared_fsdb.py
+++ b/src/commons/plantdb/commons/cli/shared_fsdb.py
@@ -44,7 +44,7 @@ from plantdb.commons.test_database import DATASET
 from plantdb.commons.test_database import setup_test_database
 
 # Create a logger and set the environment variable
-os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[0])
+os.environ.setdefault('ROMI_APP_LOGGER', __name__.split('.')[-1])
 logger = get_logger(os.getenv('ROMI_APP_LOGGER'), log_level=DEFAULT_LOG_LEVEL)
 
 

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -52,7 +52,6 @@ classifiers = [
 
 [project.scripts]
 fsdb_rest_api = "plantdb.server.cli.fsdb_rest_api:main"
-fsdb_healthcheck = "plantdb.comons.cli.fsdb_healthcheck:main"
 
 [project.urls]
 homepage = "https://romi-project.eu/"


### PR DESCRIPTION
## Summary of changes

- Refactored logger initialization in all FSDB CLI modules (`fsdb_rest_api_sync.py`, `fsdb_healthcheck.py`, `fsdb_import_folder.py`, `fsdb_import_images.py`, `fsdb_import_file.py`, `shared_fsdb.py`):
  - Defined `ROMI_APP_LOGGER` using `__name__.split('.')[-1]` to capture the module’s basename.
  - Created the logger with `os.getenv('ROMI_APP_LOGGER')` after the environment variable is set.
- Ensured consistent logger naming across all CLI commands.

## Others
- Deleted the `fsdb_healthcheck` entry from `plantdb/src/server/pyproject.toml` as this is a CLI from `plantdb.commons`.